### PR TITLE
B13: single source of truth for country/lang defaults + validation

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,7 @@
+# Default country for queries (ISO 3166-1 alpha-2). Overrides built-in 'US'.
 export COUNTRY_OF_QUERY=IN
+# Default language for queries (BCP-47 tag). Overrides built-in 'en'.
+export LANG_OF_QUERY=en
 export LOGGING=true
 export RATE_LIMIT_WINDOW_MS=900000
 export RATE_LIMIT_MAX_REQUESTS=100

--- a/docs/deployment.html
+++ b/docs/deployment.html
@@ -14,6 +14,7 @@
       <a href="/docs/endpoints.html">Endpoints</a>
       <a href="/docs/errors.html">Errors</a>
       <a href="/docs/throttling.html">Throttling</a>
+      <a href="/docs/localization.html">Localization</a>
       <a href="/docs/deployment.html">Deployment</a>
       <a href="/docs/roadmap.html">v2 Roadmap</a>
     </nav>

--- a/docs/endpoints.html
+++ b/docs/endpoints.html
@@ -14,6 +14,8 @@
       <a href="/docs/endpoints.html">Endpoints</a>
       <a href="/docs/errors.html">Errors</a>
       <a href="/docs/throttling.html">Throttling</a>
+      <a href="/docs/localization.html">Localization</a>
+      <a href="/docs/localization.html">Localization</a>
       <a href="/docs/deployment.html">Deployment</a>
       <a href="/docs/roadmap.html">v2 Roadmap</a>
     </nav>

--- a/docs/errors.html
+++ b/docs/errors.html
@@ -14,6 +14,8 @@
       <a href="/docs/endpoints.html">Endpoints</a>
       <a href="/docs/errors.html">Errors</a>
       <a href="/docs/throttling.html">Throttling</a>
+      <a href="/docs/localization.html">Localization</a>
+      <a href="/docs/localization.html">Localization</a>
       <a href="/docs/deployment.html">Deployment</a>
       <a href="/docs/roadmap.html">v2 Roadmap</a>
     </nav>

--- a/docs/index.html
+++ b/docs/index.html
@@ -14,6 +14,7 @@
       <a href="/docs/endpoints.html">Endpoints</a>
       <a href="/docs/errors.html">Errors</a>
       <a href="/docs/throttling.html">Throttling</a>
+      <a href="/docs/localization.html">Localization</a>
       <a href="/docs/deployment.html">Deployment</a>
       <a href="/docs/roadmap.html">v2 Roadmap</a>
     </nav>
@@ -48,8 +49,8 @@
     <h2>Common options</h2>
     <table>
       <tr><th>Param</th><th>Default</th><th>Description</th></tr>
-      <tr><td><code>country</code></td><td><code>IN</code></td><td>Storefront country code (ISO 3166-1 alpha-2)</td></tr>
-      <tr><td><code>lang</code></td><td>—</td><td>UI language (ISO 639-1, e.g. <code>en</code>, <code>ta</code>)</td></tr>
+      <tr><td><code>country</code></td><td><code>US</code></td><td>Storefront country code (ISO 3166-1 alpha-2). Override via <code>COUNTRY_OF_QUERY</code> env. See <a href="/docs/localization.html">localization</a></td></tr>
+      <tr><td><code>lang</code></td><td><code>en</code></td><td>UI language (ISO 639-1, e.g. <code>en</code>, <code>ta</code>). Override via <code>LANG_OF_QUERY</code> env. See <a href="/docs/localization.html">localization</a></td></tr>
       <tr><td><code>num</code></td><td><code>20</code></td><td>Results per page (list endpoints, max 200)</td></tr>
       <tr><td><code>throttling</code></td><td><code>disabled</code></td><td>See <a href="/docs/throttling.html">throttling</a> for v2 deployment</td></tr>
     </table>

--- a/docs/localization.html
+++ b/docs/localization.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Localization — Google Play API</title>
+  <link rel="stylesheet" href="/docs/css/style.css" />
+</head>
+<body>
+  <header class="topbar">
+    <a class="brand" href="/docs/">gplay<span class="accent">api</span></a>
+    <nav>
+      <a href="/docs/">Home</a>
+      <a href="/docs/endpoints.html">Endpoints</a>
+      <a href="/docs/errors.html">Errors</a>
+      <a href="/docs/throttling.html">Throttling</a>
+      <a href="/docs/localization.html">Localization</a>
+      <a href="/docs/deployment.html">Deployment</a>
+      <a href="/docs/roadmap.html">v2 Roadmap</a>
+    </nav>
+  </header>
+
+  <main>
+    <h1>Localization: country &amp; lang</h1>
+    <p class="lead">
+      Every request targets a Google Play storefront. Two parameters control
+      which store and which language you see: <code>country</code> and <code>lang</code>.
+    </p>
+
+    <h2>Single source of truth</h2>
+    <p>
+      Defaults are resolved in one place — the router middleware in
+      <code>lib/index.js</code> — using constants from <code>lib/constants.js</code>.
+      There is no per-route override logic.
+    </p>
+    <table>
+      <tr><th>Layer</th><th>Value</th><th>Notes</th></tr>
+      <tr><td>Query param</td><td><code>?country=IN&amp;lang=ta</code></td><td>Highest priority. Validated per request.</td></tr>
+      <tr><td>Env override</td><td><code>COUNTRY_OF_QUERY</code> / <code>LANG_OF_QUERY</code></td><td>Server-wide default when no query param is given.</td></tr>
+      <tr><td>Code constant</td><td><code>DEFAULT_COUNTRY='US'</code> / <code>DEFAULT_LANG='en'</code></td><td>Fallback when env is unset.</td></tr>
+    </table>
+
+    <h2>Validation</h2>
+    <ul>
+      <li><code>country</code> — ISO 3166-1 alpha-2, case-insensitive. Normalized to uppercase before use. Invalid codes return <code>400</code> with <code>application/problem+json</code> on <code>/v2</code>.</li>
+      <li><code>lang</code> — ISO 639-1, case-insensitive. Normalized to lowercase. Invalid codes return <code>400</code>.</li>
+    </ul>
+
+    <h2>Country / lang matrix</h2>
+    <p>
+      The scraper passes <code>country</code> and <code>lang</code> directly to the
+      Play Store batchexecute endpoint. Any valid ISO pair is accepted — the API
+      does not maintain a hardcoded allowlist. Common combinations:
+    </p>
+    <table>
+      <tr><th>country</th><th>lang</th><th>Storefront</th></tr>
+      <tr><td><code>US</code></td><td><code>en</code></td><td>United States (default)</td></tr>
+      <tr><td><code>IN</code></td><td><code>en</code></td><td>India, English</td></tr>
+      <tr><td><code>IN</code></td><td><code>ta</code></td><td>India, Tamil</td></tr>
+      <tr><td><code>IN</code></td><td><code>hi</code></td><td>India, Hindi</td></tr>
+      <tr><td><code>GB</code></td><td><code>en</code></td><td>United Kingdom</td></tr>
+      <tr><td><code>DE</code></td><td><code>de</code></td><td>Germany</td></tr>
+      <tr><td><code>JP</code></td><td><code>ja</code></td><td>Japan</td></tr>
+      <tr><td><code>BR</code></td><td><code>pt</code></td><td>Brazil</td></tr>
+    </table>
+    <p>
+      <strong>Note:</strong> not every app is available in every storefront.
+      A valid request may still return <code>404 App not found</code> if the app
+      is geo-restricted.
+    </p>
+
+    <h2>Examples</h2>
+<pre><code># Default (US / en)
+curl "https://gplayapiv2.fly.dev/v2/apps/com.instagram.android"
+
+# Indian storefront, Tamil UI
+curl "https://gplayapiv2.fly.dev/v2/apps/com.instagram.android?country=IN&amp;lang=ta"
+
+# Invalid country → 400 problem+json
+curl "https://gplayapiv2.fly.dev/v2/apps/com.instagram.android?country=XX"</code></pre>
+
+    <h2>Environment configuration</h2>
+<pre><code># .env
+COUNTRY_OF_QUERY=IN
+LANG_OF_QUERY=en</code></pre>
+    <p>
+      The <code>gplayapiv2</code> verification deployment sets
+      <code>COUNTRY_OF_QUERY=IN</code> to match the primary audience.
+      Production (<code>main</code>) uses the code default (<code>US</code>/<code>en</code>)
+      unless overridden.
+    </p>
+  </main>
+
+  <footer>
+    <p>Google Play API · <a href="https://github.com/srikanthlogic/google-play-api">github.com/srikanthlogic/google-play-api</a></p>
+  </footer>
+  <script src="/docs/js/main.js"></script>
+</body>
+</html>

--- a/docs/roadmap.html
+++ b/docs/roadmap.html
@@ -14,6 +14,8 @@
       <a href="/docs/endpoints.html">Endpoints</a>
       <a href="/docs/errors.html">Errors</a>
       <a href="/docs/throttling.html">Throttling</a>
+      <a href="/docs/localization.html">Localization</a>
+      <a href="/docs/localization.html">Localization</a>
       <a href="/docs/deployment.html">Deployment</a>
       <a href="/docs/roadmap.html">v2 Roadmap</a>
     </nav>

--- a/docs/throttling.html
+++ b/docs/throttling.html
@@ -14,6 +14,8 @@
       <a href="/docs/endpoints.html">Endpoints</a>
       <a href="/docs/errors.html">Errors</a>
       <a href="/docs/throttling.html">Throttling</a>
+      <a href="/docs/localization.html">Localization</a>
+      <a href="/docs/localization.html">Localization</a>
       <a href="/docs/deployment.html">Deployment</a>
       <a href="/docs/roadmap.html">v2 Roadmap</a>
     </nav>

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -22,5 +22,15 @@ export const SORT_HELPFUL = 1;
 export const SORT_NEWEST = 2;
 export const SORT_RATED = 3;
 
-// Default country
-export const DEFAULT_COUNTRY = 'US';
+// ─── Country / Language defaults (single source of truth) ───────────────────
+// Resolution order: env var → constant. The scraper itself defaults to
+// country="us", lang="en" when neither is provided, but we always pass
+// explicit values so behaviour is deterministic and documented.
+export const DEFAULT_COUNTRY = (process.env.COUNTRY_OF_QUERY || 'US').toUpperCase();
+export const DEFAULT_LANG = (process.env.LANG_OF_QUERY || 'en').toLowerCase();
+
+// ISO 3166-1 alpha-2 pattern (2 uppercase letters)
+export const COUNTRY_CODE_RE = /^[A-Z]{2}$/;
+
+// BCP-47-ish language tag: 2-letter base, optional region subtag
+export const LANG_CODE_RE = /^[a-z]{2}(-[A-Za-z]{2,4})?$/;

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,10 @@ import {
   SORT_HELPFUL,
   SORT_NEWEST,
   SORT_RATED,
-  DEFAULT_COUNTRY
+  DEFAULT_COUNTRY,
+  DEFAULT_LANG,
+  COUNTRY_CODE_RE,
+  LANG_CODE_RE
 } from './constants.js';
 import logger from './logger.js';
 import { buildUrl, cleanUrls } from './urlUtils.js';
@@ -49,8 +52,34 @@ const handleValidationErrors = (req, res, next) => {
 const toList = (apps) => ({ results: apps });
 
 router.use((req, res, next) => {
+  // Country: default from single source of truth, validate format
   if (!req.query.country) {
-    req.query.country = process.env.COUNTRY_OF_QUERY || DEFAULT_COUNTRY;
+    req.query.country = DEFAULT_COUNTRY;
+  } else {
+    req.query.country = req.query.country.toUpperCase();
+    if (!COUNTRY_CODE_RE.test(req.query.country)) {
+      const error = new Error('country must be a valid ISO 3166-1 alpha-2 code (e.g. US, IN, GB)');
+      error.code = 'VALIDATION_ERROR';
+      if (req.baseUrl === '/v2') {
+        return res.status(400).type('application/problem+json').json(problemDetails(error, req, 400));
+      }
+      return res.status(400).json({ error: 'Validation failed', messages: [error.message] });
+    }
+  }
+
+  // Language: default from single source of truth, validate format
+  if (!req.query.lang) {
+    req.query.lang = DEFAULT_LANG;
+  } else {
+    req.query.lang = req.query.lang.toLowerCase();
+    if (!LANG_CODE_RE.test(req.query.lang)) {
+      const error = new Error('lang must be a valid BCP-47 language tag (e.g. en, hi, ta-IN)');
+      error.code = 'VALIDATION_ERROR';
+      if (req.baseUrl === '/v2') {
+        return res.status(400).type('application/problem+json').json(problemDetails(error, req, 400));
+      }
+      return res.status(400).json({ error: 'Validation failed', messages: [error.message] });
+    }
   }
 
   if (process.env.LOGGING || false) {

--- a/test.js
+++ b/test.js
@@ -84,6 +84,16 @@ const runTests = async () => {
     const v2AppResponse = await contractFetch('http://127.0.0.1:3000/v2/apps/com.google.android.apps.translate?country=US&lang=en');
     if (v2AppResponse.status !== 200) throw new Error(`v2 app endpoint returned ${v2AppResponse.status}`);
 
+    // B13: country/lang validation contract checks
+    const badCountry = await contractFetch('http://127.0.0.1:3000/v2/apps/com.google.android.apps.translate?country=USA');
+    if (badCountry.status !== 400) throw new Error(`invalid country must return 400, got ${badCountry.status}`);
+
+    const badLang = await contractFetch('http://127.0.0.1:3000/v2/apps/com.google.android.apps.translate?lang=english');
+    if (badLang.status !== 400) throw new Error(`invalid lang must return 400, got ${badLang.status}`);
+
+    const defaultCountry = await contractFetch('http://127.0.0.1:3000/v2/apps/com.google.android.apps.translate');
+    if (defaultCountry.status !== 200) throw new Error(`default country/lang request returned ${defaultCountry.status}`);
+
     console.log('\nAPI tests completed successfully!');
   } catch (err) {
     console.error('Test execution error:', err);


### PR DESCRIPTION
## Summary

Resolves the `COUNTRY_OF_QUERY=IN` env vs `DEFAULT_COUNTRY='US'` constant conflict (issue #115).

## Changes

- **`lib/constants.js`** — `DEFAULT_COUNTRY` and `DEFAULT_LANG` now resolve from env vars (`COUNTRY_OF_QUERY`, `LANG_OF_QUERY`) with `US`/`en` fallbacks. Added `COUNTRY_CODE_RE` (ISO 3166-1 alpha-2) and `LANG_CODE_RE` (BCP-47-ish) validation patterns.
- **`lib/index.js`** — Router middleware normalises country to uppercase, validates format, validates lang format. Returns 400 with `application/problem+json` on `/v2` routes.
- **`test.js`** — Contract checks: invalid country → 400, invalid lang → 400, default country/lang request → 200.
- **`docs/localization.html`** — New microsite page documenting the country/lang matrix, resolution order, and validation rules.
- **`.env.sample`** — Documents `LANG_OF_QUERY`.
- Nav updated across all docs pages.

## Verification

- `npx eslint lib/ test.js server.js` — clean
- `npm test` — 12 requests, 70 tests, all contract checks pass

Closes #115