### PR TITLE
H2: honor Express err.status so unknown routes return 404 not 500 (#169)

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -61,6 +61,11 @@ export const getErrorStatusCode = (err) => {
     return err.statusCode;
   }
 
+  // Express convention: middleware sets err.status (e.g. the 404 catchall)
+  if (typeof err.status === 'number') {
+    return err.status;
+  }
+
   if (err.name === 'UpstreamSchemaDriftError' || err.code === 'UPSTREAM_SCHEMA_DRIFT') {
     return 502;
   }

--- a/test/errors-status.test.js
+++ b/test/errors-status.test.js
@@ -1,0 +1,24 @@
+'use strict';
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { AppError, getErrorStatusCode } from '../lib/errors.js';
+
+test('getErrorStatusCode honors Express-style err.status', () => {
+  const err = new Error('Not Found');
+  err.status = 404;
+  assert.equal(getErrorStatusCode(err), 404);
+});
+
+test('err.status does not override AppError statusCode', () => {
+  // AppError branch runs first; its statusCode wins over a stray .status
+  const err = new AppError('teapot', 418);
+  err.status = 500;
+  assert.equal(getErrorStatusCode(err), 418);
+});
+
+test('non-numeric err.status is ignored', () => {
+  const err = new Error('mystery');
+  err.status = 'not-a-number';
+  assert.equal(getErrorStatusCode(err), 500);
+});

--- a/v2-plan/DEFICIENCIES.md
+++ b/v2-plan/DEFICIENCIES.md
@@ -119,8 +119,8 @@
 
 | # | Atomic issue | Type | Notes |
 |---|-------------|------|-------|
-| H1 | No unit tests for `lib/` or `server.js`; coverage not enforced | debt | Add node:test unit suite (mocked scraper) + c8 coverage in CI. Baseline: lib/index.js 97%, logger.js 70%, server.js 0% (untestable — calls `app.listen()` at import). Extract `createApp()` factory. |
-| H2 | Unknown routes return 500 instead of 404 | bug | Catchall sets `err.status = 404` but `getErrorStatusCode()` never reads `.status`; message `'Not Found'` fails the lowercase `'not found'` check. Verified live: `GET /definitely-not-a-route` → 500 problem+json. Fix: honor `err.status`/`err.statusCode` in `getErrorStatusCode`. |
+| H1 | No unit tests for `lib/` or `server.js`; coverage not enforced | debt | Add node:test unit suite (mocked scraper) + c8 coverage in CI. Baseline: lib/index.js 97%, logger.js 70%, server.js 0% (untestable — calls `app.listen()` at import). Extract `createApp()` factory. Done: PR #171 (72 tests, 97.66% stmts), merged e0922ec. |
+| H2 | Unknown routes return 500 instead of 404 | bug | Catchall sets `err.status = 404` but `getErrorStatusCode()` never reads `.status`; message `'Not Found'` fails the lowercase `'not found'` check. Verified live: `GET /definitely-not-a-route` → 500 problem+json. Fix: honor `err.status`/`err.statusCode` in `getErrorStatusCode`. PR #170. |
 
 ---
 


### PR DESCRIPTION
## Summary

Fixes #169.

`getErrorStatusCode()` never checked Express's `err.status` convention, so the 404 catchall's `err.status = 404` was ignored and every unknown route returned **500**. Verified live on gplayapiv2.fly.dev before the fix:

```
GET /definitely-not-a-route → 500 {"code":"HTTP_500",...}
```

## Changes

- `lib/errors.js`: check `typeof err.status === 'number'` after the `AppError` branch (AppError.statusCode still wins over a stray `.status`)
- `test/errors-status.test.js`: 3 regression tests — 404 case, AppError precedence, non-numeric status ignored

## Verification

- [x] `node --test test/errors-status.test.js` — 3/3 pass
- [x] `npx eslint .` clean
- [ ] CI validate green
- [ ] Post-deploy: `GET https://gplayapiv2.fly.dev/definitely-not-a-route` → 404 problem+json