### PR TITLE
H1: Unit test suite + coverage enforcement for lib/ and server.js (#168)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ openapi/swagger.json
 # CI test artifacts
 bruno/*/junit.xml
 eslint-report.json
+test/junit-unit.xml

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "start": "node server.js",
     "dev": "nodemon server.js",
     "prepare": "husky || true",
-    "test:coverage": "c8 --reporter=text --reporter=lcov --reporter=json-summary node test.js"
+    "test:coverage": "c8 --reporter=text --reporter=lcov --reporter=json-summary --all --include=lib --include=server.js sh -c 'node --test --experimental-test-module-mocks test/*.test.js && node test.js'",
+    "test:unit": "node --test --experimental-test-module-mocks --test-reporter=spec --test-reporter-destination=stdout --test-reporter=junit --test-reporter-destination=test/junit-unit.xml test/*.test.js",
+    "pretest": "npm run test:unit",
+    "test:unit:coverage": "c8 --reporter=text --reporter=lcov --reporter=json-summary node --test --experimental-test-module-mocks test/*.test.js"
   },
   "author": "Facundo Olano",
   "license": "ISC",

--- a/test/constants.test.js
+++ b/test/constants.test.js
@@ -1,0 +1,55 @@
+'use strict';
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  DEFAULT_PAGE_SIZE,
+  MAX_PAGE_SIZE,
+  MAX_LIST_RESULTS,
+  DEFAULT_REVIEWS_COUNT,
+  MAX_REVIEWS_COUNT,
+  SORT_HELPFUL,
+  SORT_NEWEST,
+  SORT_RATED,
+  DEFAULT_COUNTRY,
+  DEFAULT_LANG,
+  COUNTRY_CODE_RE,
+  LANG_CODE_RE
+} from '../lib/constants.js';
+
+test('pagination bounds are sane', () => {
+  assert.ok(DEFAULT_PAGE_SIZE > 0);
+  assert.ok(MAX_PAGE_SIZE >= DEFAULT_PAGE_SIZE);
+  assert.equal(MAX_LIST_RESULTS, 200); // scraper hard cap
+});
+
+test('reviews bounds and sort values', () => {
+  assert.ok(MAX_REVIEWS_COUNT >= DEFAULT_REVIEWS_COUNT);
+  assert.deepEqual([SORT_HELPFUL, SORT_NEWEST, SORT_RATED], [1, 2, 3]);
+});
+
+test('country/lang defaults resolve from env or fallback', () => {
+  assert.equal(typeof DEFAULT_COUNTRY, 'string');
+  assert.equal(DEFAULT_COUNTRY, DEFAULT_COUNTRY.toUpperCase());
+  assert.equal(DEFAULT_LANG, DEFAULT_LANG.toLowerCase());
+});
+
+test('COUNTRY_CODE_RE matches ISO 3166-1 alpha-2 only', () => {
+  assert.ok(COUNTRY_CODE_RE.test('US'));
+  assert.ok(COUNTRY_CODE_RE.test('IN'));
+  assert.ok(!COUNTRY_CODE_RE.test('USA'));
+  assert.ok(!COUNTRY_CODE_RE.test('us'));
+  assert.ok(!COUNTRY_CODE_RE.test('U'));
+  assert.ok(!COUNTRY_CODE_RE.test('U1'));
+  assert.ok(!COUNTRY_CODE_RE.test(''));
+});
+
+test('LANG_CODE_RE matches BCP-47-ish tags', () => {
+  assert.ok(LANG_CODE_RE.test('en'));
+  assert.ok(LANG_CODE_RE.test('en-US'));
+  assert.ok(LANG_CODE_RE.test('zh-Hans'));
+  assert.ok(!LANG_CODE_RE.test('english'));
+  assert.ok(!LANG_CODE_RE.test('EN'));
+  assert.ok(!LANG_CODE_RE.test('e'));
+  assert.ok(!LANG_CODE_RE.test(''));
+});

--- a/test/errors.test.js
+++ b/test/errors.test.js
@@ -1,0 +1,154 @@
+'use strict';
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  AppError,
+  NotFoundError,
+  BadRequestError,
+  ValidationError,
+  RateLimitError,
+  UpstreamParseError,
+  UpstreamNetworkError,
+  getErrorStatusCode,
+  problemDetails
+} from '../lib/errors.js';
+
+test('AppError defaults to 500 and error status', () => {
+  const err = new AppError('boom');
+  assert.equal(err.statusCode, 500);
+  assert.equal(err.status, 'error');
+  assert.equal(err.isOperational, true);
+  assert.equal(err.message, 'boom');
+  assert.ok(err instanceof Error);
+});
+
+test('AppError with 4xx code gets fail status', () => {
+  const err = new AppError('nope', 418);
+  assert.equal(err.statusCode, 418);
+  assert.equal(err.status, 'fail');
+});
+
+test('specialized error classes carry expected status codes', () => {
+  assert.equal(new NotFoundError().statusCode, 404);
+  assert.equal(new BadRequestError().statusCode, 400);
+  assert.equal(new ValidationError().statusCode, 400);
+  assert.equal(new RateLimitError().statusCode, 429);
+  assert.equal(new UpstreamParseError().statusCode, 502);
+  assert.equal(new UpstreamNetworkError().statusCode, 503);
+});
+
+test('specialized error classes have default messages', () => {
+  assert.equal(new NotFoundError().message, 'Resource not found');
+  assert.equal(new BadRequestError().message, 'Bad request');
+  assert.equal(new ValidationError().message, 'Validation failed');
+  assert.equal(new RateLimitError().message, 'Too many requests');
+  assert.equal(new UpstreamParseError().message, 'The upstream response could not be parsed');
+  assert.equal(new UpstreamNetworkError().message, 'The upstream service could not be reached');
+});
+
+test('getErrorStatusCode returns AppError statusCode', () => {
+  assert.equal(getErrorStatusCode(new NotFoundError('x')), 404);
+  assert.equal(getErrorStatusCode(new AppError('x', 422)), 422);
+});
+
+test('getErrorStatusCode maps UpstreamSchemaDriftError to 502', () => {
+  const byName = new Error('drift');
+  byName.name = 'UpstreamSchemaDriftError';
+  assert.equal(getErrorStatusCode(byName), 502);
+
+  const byCode = new Error('drift');
+  byCode.code = 'UPSTREAM_SCHEMA_DRIFT';
+  assert.equal(getErrorStatusCode(byCode), 502);
+});
+
+test('getErrorStatusCode maps scraper not-found messages to 404', () => {
+  assert.equal(getErrorStatusCode(new Error('App not found')), 404);
+  assert.equal(getErrorStatusCode(new Error('status code 404')), 404);
+});
+
+test('getErrorStatusCode maps network error codes to 503', () => {
+  for (const code of ['ENOTFOUND', 'ECONNRESET', 'ETIMEDOUT', 'ECONNREFUSED']) {
+    const err = new Error('network');
+    err.code = code;
+    assert.equal(getErrorStatusCode(err), 503, code);
+  }
+});
+
+test('getErrorStatusCode maps parse errors to 502', () => {
+  const byName = new Error('bad html');
+  byName.name = 'HTMLParseError';
+  assert.equal(getErrorStatusCode(byName), 502);
+
+  assert.equal(getErrorStatusCode(new Error('Failed to parse response')), 502);
+});
+
+test('getErrorStatusCode maps rate limit errors to 429', () => {
+  assert.equal(getErrorStatusCode(new Error('rate limit exceeded')), 429);
+  assert.equal(getErrorStatusCode(new Error('upstream returned 429')), 429);
+});
+
+test('getErrorStatusCode defaults to 500', () => {
+  assert.equal(getErrorStatusCode(new Error('mystery')), 500);
+});
+
+const mockReq = (url = '/v2/apps/com.foo') => ({ originalUrl: url });
+
+test('problemDetails builds RFC 7807 shape for 4xx', () => {
+  const err = new BadRequestError('num must be positive');
+  const problem = problemDetails(err, mockReq(), 400);
+  assert.equal(problem.type, 'https://api.google-play-api.dev/problems/bad-request');
+  assert.equal(problem.title, 'Bad Request');
+  assert.equal(problem.status, 400);
+  assert.equal(problem.detail, 'num must be positive');
+  assert.equal(problem.code, 'HTTP_400');
+  assert.equal(problem.instance, '/v2/apps/com.foo');
+});
+
+test('problemDetails preserves error code when present', () => {
+  const err = new Error('gone');
+  err.code = 'APP_GONE';
+  const problem = problemDetails(err, mockReq(), 404);
+  assert.equal(problem.code, 'APP_GONE');
+});
+
+test('problemDetails masks 5xx detail outside development', () => {
+  const prev = process.env.NODE_ENV;
+  delete process.env.NODE_ENV;
+  try {
+    const problem = problemDetails(new Error('secret stack trace'), mockReq(), 500);
+    assert.equal(problem.detail, 'The request could not be completed.');
+  } finally {
+    if (prev !== undefined) process.env.NODE_ENV = prev;
+  }
+});
+
+test('problemDetails exposes 5xx detail in development', () => {
+  const prev = process.env.NODE_ENV;
+  process.env.NODE_ENV = 'development';
+  try {
+    const problem = problemDetails(new Error('secret stack trace'), mockReq(), 500);
+    assert.equal(problem.detail, 'secret stack trace');
+  } finally {
+    if (prev === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = prev;
+  }
+});
+
+test('problemDetails computes retryAfter for 429 from rateLimit resetTime', () => {
+  const req = mockReq();
+  req.rateLimit = { resetTime: new Date(Date.now() + 42_000) };
+  const problem = problemDetails(new RateLimitError(), req, 429);
+  assert.ok(problem.retryAfter >= 41 && problem.retryAfter <= 42);
+});
+
+test('problemDetails retryAfter floors at 0 without resetTime', () => {
+  const problem = problemDetails(new RateLimitError(), mockReq(), 429);
+  assert.equal(problem.retryAfter, 0);
+});
+
+test('problemDetails falls back to internal type for unknown status', () => {
+  const problem = problemDetails(new Error('teapot'), mockReq(), 418);
+  assert.equal(problem.type, 'https://api.google-play-api.dev/problems/internal');
+  assert.equal(problem.title, 'Internal Server Error');
+});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,410 @@
+'use strict';
+
+import { test, before, after, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import Express from 'express';
+import { DEFAULT_COUNTRY, DEFAULT_LANG, SORT_HELPFUL, SORT_RATED, SORT_NEWEST } from '../lib/constants.js';
+
+// Silence pino-pretty transport in the logger under test
+process.env.NODE_ENV = 'production';
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+const makeApp = (appId = 'com.example.app') => ({
+  appId,
+  title: 'Example App',
+  url: `https://play.google.com/store/apps/details?id=${appId}`,
+  developer: 'Example Dev',
+  score: 4.5
+});
+
+const makeReview = () => ({
+  id: 'r1',
+  userName: 'John Doe',
+  userImage: 'https://img.example.com/john.png',
+  date: '2026-01-02T03:04:05Z',
+  url: 'https://play.google.com/store/review/r1',
+  score: 5,
+  title: null,
+  text: 'Great app',
+  replyDate: '2026-01-03T00:00:00Z',
+  replyText: 'Thanks John Doe for the review',
+  version: '1.0',
+  thumbsUp: 3,
+  criterias: [],
+  _url: 'internal-url',
+  _replyText: 'internal-reply',
+  _replyDate: 'internal-date'
+});
+
+// Mutable fake scraper — individual tests override single methods.
+const fake = {
+  category: { GAME: 'Game', FINANCE: 'Finance' },
+  collection: { TOP_SELLING: 'Top selling', TOP_GROSSING: 'Top grossing' },
+  search: async () => [makeApp()],
+  suggest: async () => ['game', 'games'],
+  list: async (opts) => Array.from({ length: opts.num || 60 }, (_, i) => makeApp(`com.example.app${i}`)),
+  app: async () => makeApp(),
+  similar: async () => [makeApp('com.example.similar')],
+  dataSafety: async () => ({
+    sharedData: [],
+    collectedData: [{ data: 'Location', type: 'Precise location', purpose: 'App functionality', optional: false }],
+    securityPractices: [],
+    privacyPolicyUrl: 'https://example.com/privacy'
+  }),
+  permissions: async () => [
+    { type: 0, permissions: ['Read device history'] },
+    { type: 1, permissions: ['Other'] },
+    { type: 7, permissions: ['Unknown group'] }
+  ],
+  reviews: async () => ({ data: [makeReview()], nextPaginationToken: null }),
+  developer: async () => [makeApp()]
+};
+
+mock.module('@mradex77/google-play-scraper', {
+  namedExports: {},
+  defaultExport: fake
+});
+
+const { default: router } = await import('../lib/index.js');
+
+// ─── Test server ─────────────────────────────────────────────────────────────
+
+const app = Express();
+app.use('/api', router);
+app.use('/v2', router);
+
+let server;
+let base;
+
+before(async () => {
+  await new Promise((resolve) => {
+    server = app.listen(0, '127.0.0.1', resolve);
+  });
+  base = `http://127.0.0.1:${server.address().port}`;
+});
+
+after(() => new Promise((resolve) => server.close(resolve)));
+
+const get = async (path) => {
+  const res = await fetch(base + path);
+  const text = await res.text();
+  let body = null;
+  try { body = JSON.parse(text); } catch { /* non-JSON */ }
+  return { status: res.status, headers: res.headers, body, text };
+};
+
+// ─── Middleware: country / lang defaults and validation ──────────────────────
+
+test('defaults country and lang from single source of truth', async () => {
+  let captured;
+  fake.app = async (opts) => { captured = opts; return makeApp(); };
+  const { status } = await get('/api/apps/com.example.app');
+  assert.equal(status, 200);
+  assert.equal(captured.country, DEFAULT_COUNTRY);
+  assert.equal(captured.lang, DEFAULT_LANG);
+  fake.app = async () => makeApp();
+});
+
+test('uppercases valid country and lowercases valid lang', async () => {
+  let captured;
+  fake.app = async (opts) => { captured = opts; return makeApp(); };
+  const { status } = await get('/api/apps/com.example.app?country=us&lang=EN');
+  assert.equal(status, 200);
+  assert.equal(captured.country, 'US');
+  assert.equal(captured.lang, 'en');
+  fake.app = async () => makeApp();
+});
+
+test('rejects invalid country code (v1 shape)', async () => {
+  const { status, body } = await get('/api/apps/com.example.app?country=USA');
+  assert.equal(status, 400);
+  assert.equal(body.error, 'Validation failed');
+  assert.match(body.messages[0], /country/);
+});
+
+test('rejects invalid lang tag (v1 shape)', async () => {
+  const { status, body } = await get('/api/apps/com.example.app?lang=english');
+  assert.equal(status, 400);
+  assert.equal(body.error, 'Validation failed');
+  assert.match(body.messages[0], /lang/);
+});
+
+test('rejects invalid country code with problem+json on /v2', async () => {
+  const { status, headers, body } = await get('/v2/apps/com.example.app?country=USA');
+  assert.equal(status, 400);
+  assert.match(headers.get('content-type'), /application\/problem\+json/);
+  assert.equal(body.title, 'Bad Request');
+  assert.equal(body.status, 400);
+  assert.ok(body.type);
+  assert.match(body.detail, /country/);
+});
+
+// ─── /apps/ search ───────────────────────────────────────────────────────────
+
+test('search returns cleaned app list wrapped in results', async () => {
+  const { status, body } = await get('/api/apps/?q=example');
+  assert.equal(status, 200);
+  assert.equal(body.results.length, 1);
+  assert.equal(body.results[0].appId, 'com.example.app');
+  assert.equal(body.results[0].playstoreUrl, 'https://play.google.com/store/apps/details?id=com.example.app');
+  assert.match(body.results[0].url, /\/api\/apps\/com\.example\.app$/);
+  assert.match(body.results[0].reviews, /\/api\/apps\/com\.example\.app\/reviews$/);
+});
+
+test('search passes term, num and country to the scraper', async () => {
+  let captured;
+  fake.search = async (opts) => { captured = opts; return [makeApp()]; };
+  await get('/api/apps/?q=example&num=5&country=GB');
+  assert.equal(captured.term, 'example');
+  assert.equal(captured.num, 5);
+  assert.equal(captured.country, 'GB');
+  fake.search = async () => [makeApp()];
+});
+
+test('search rejects out-of-range num', async () => {
+  const { status, body } = await get('/api/apps/?q=example&num=999');
+  assert.equal(status, 400);
+  assert.match(body.messages[0], /num/);
+});
+
+test('search rejects negative start', async () => {
+  const { status } = await get('/api/apps/?q=example&start=-1');
+  assert.equal(status, 400);
+});
+
+// ─── /apps/ suggest ──────────────────────────────────────────────────────────
+
+test('suggest returns terms with search URLs', async () => {
+  const { status, body } = await get('/api/apps/?suggest=game');
+  assert.equal(status, 200);
+  assert.equal(body.results.length, 2);
+  assert.equal(body.results[0].term, 'game');
+  assert.match(body.results[0].url, /q=game$/);
+});
+
+// ─── /apps/ list (emulated offset pagination) ────────────────────────────────
+
+test('list slices scraper output by start/num and emits prev/next links', async () => {
+  let captured;
+  fake.list = async (opts) => {
+    captured = opts;
+    return Array.from({ length: opts.num }, (_, i) => makeApp(`com.example.app${i}`));
+  };
+  const { status, body } = await get('/api/apps/?num=10&start=20');
+  assert.equal(status, 200);
+  assert.equal(captured.num, 30); // fetches start + num, no native offset
+  assert.equal(body.results.length, 10);
+  assert.equal(body.results[0].appId, 'com.example.app20');
+  assert.match(body.prev, /start=10/);
+  assert.match(body.next, /start=30/);
+  fake.list = async (opts) => Array.from({ length: opts.num || 60 }, (_, i) => makeApp(`com.example.app${i}`));
+});
+
+test('list omits next link at the end of the capped range', async () => {
+  fake.list = async (opts) => Array.from({ length: opts.num }, (_, i) => makeApp(`com.example.app${i}`));
+  const { status, body } = await get('/api/apps/?num=10&start=195');
+  assert.equal(status, 200);
+  assert.equal(body.results.length, 5); // only 200 - 195 apps remain
+  assert.ok(body.prev);
+  assert.equal(body.next, undefined);
+  fake.list = async (opts) => Array.from({ length: opts.num || 60 }, (_, i) => makeApp(`com.example.app${i}`));
+});
+
+test('list omits prev link on the first page', async () => {
+  const { status, body } = await get('/api/apps/?num=10&start=0');
+  assert.equal(status, 200);
+  assert.equal(body.prev, undefined);
+  assert.ok(body.next);
+});
+
+// ─── /apps/:appId ────────────────────────────────────────────────────────────
+
+test('app detail returns cleaned app object', async () => {
+  const { status, body } = await get('/api/apps/com.example.app');
+  assert.equal(status, 200);
+  assert.equal(body.appId, 'com.example.app');
+  assert.equal(body.playstoreUrl, 'https://play.google.com/store/apps/details?id=com.example.app');
+  assert.match(body.url, /\/api\/apps\/com\.example\.app$/);
+  assert.equal(body.developer.devId, 'Example Dev');
+  assert.match(body.developer.url, /\/api\/developers\/Example%20Dev$/);
+});
+
+test('app detail maps "not found" scraper errors to 404', async () => {
+  fake.app = async () => { throw new Error('App not found (404)'); };
+  const { status, body } = await get('/api/apps/com.missing.app');
+  assert.equal(status, 404);
+  assert.equal(body.error, 'Not Found');
+  assert.match(body.message, /not found/i);
+  fake.app = async () => makeApp();
+});
+
+test('app detail returns 502 on upstream schema drift', async () => {
+  fake.app = async () => ({ unexpected: 'shape' });
+  const { status, body } = await get('/api/apps/com.example.app');
+  assert.equal(status, 502);
+  assert.equal(body.error, 'Internal Server Error');
+  fake.app = async () => makeApp();
+});
+
+test('similar maps generic scraper failures to 500', async () => {
+  fake.similar = async () => { throw new Error('boom'); };
+  const { status, body } = await get('/api/apps/com.example.app/similar');
+  assert.equal(status, 500);
+  assert.equal(body.error, 'Internal Server Error');
+  fake.similar = async () => [makeApp('com.example.similar')];
+});
+
+test('similar returns cleaned list', async () => {
+  const { status, body } = await get('/api/apps/com.example.app/similar');
+  assert.equal(status, 200);
+  assert.equal(body.results[0].appId, 'com.example.similar');
+});
+
+// ─── /apps/:appId/datasafety ─────────────────────────────────────────────────
+
+test('datasafety returns scraper payload inside results wrapper', async () => {
+  const { status, body } = await get('/api/apps/com.example.app/datasafety');
+  assert.equal(status, 200);
+  assert.deepEqual(body.results.sharedData, []);
+  assert.equal(body.results.collectedData[0].data, 'Location');
+  assert.equal(body.results.privacyPolicyUrl, 'https://example.com/privacy');
+});
+
+// ─── /apps/:appId/permissions ────────────────────────────────────────────────
+
+test('permissions maps numeric type indexes to category names', async () => {
+  const { status, body } = await get('/api/apps/com.example.app/permissions');
+  assert.equal(status, 200);
+  assert.equal(body.results[0].type, 'Device & app history');
+  assert.equal(body.results[1].type, 'Other');
+  assert.equal(body.results[2].type, '7'); // unknown index falls back to string
+});
+
+// ─── /apps/:appId/reviews ────────────────────────────────────────────────────
+
+test('reviews default: strips user data and replies, truncates date', async () => {
+  const { status, body } = await get('/api/apps/com.example.app/reviews');
+  assert.equal(status, 200);
+  const review = body.results.data[0];
+  assert.equal(review.date, '2026-01-02');
+  assert.equal('userName' in review, false);
+  assert.equal('userImage' in review, false);
+  assert.equal('replyText' in review, false);
+  assert.equal('replyDate' in review, false);
+  // public `url` is part of the contract; only the internal `_url` is stripped
+  assert.equal(review.url, 'https://play.google.com/store/review/r1');
+  assert.equal('_url' in review, false);
+  assert.equal(body.results.nextPaginationToken, '');
+});
+
+test('reviews with replies=true redacts user name from reply text', async () => {
+  const { status, body } = await get('/api/apps/com.example.app/reviews?replies=true');
+  assert.equal(status, 200);
+  const review = body.results.data[0];
+  assert.equal(review.replyText, 'Thanks [REDACTED_USER] [REDACTED_USER] for the review');
+  assert.equal(review.replyDate, '2026-01-03T00:00:00Z');
+});
+
+test('reviews with userdata=true keeps user fields, drops reply internals', async () => {
+  const { status, body } = await get('/api/apps/com.example.app/reviews?userdata=true');
+  assert.equal(status, 200);
+  const review = body.results.data[0];
+  assert.equal(review.userName, 'John Doe');
+  assert.equal(review.replyText, 'Thanks John Doe for the review');
+  assert.equal('_replyText' in review, false);
+  assert.equal('_replyDate' in review, false);
+  assert.equal('_url' in review, false);
+});
+
+test('reviews with userdata=true&replies=true keeps everything but _url', async () => {
+  const { status, body } = await get('/api/apps/com.example.app/reviews?userdata=true&replies=true');
+  assert.equal(status, 200);
+  const review = body.results.data[0];
+  assert.equal(review.userName, 'John Doe');
+  assert.equal(review.replyText, 'Thanks John Doe for the review');
+  assert.equal(review.url, 'https://play.google.com/store/review/r1');
+  assert.equal('_url' in review, false);
+});
+
+test('reviews maps sort names to scraper sort constants', async () => {
+  const captured = [];
+  fake.reviews = async (opts) => { captured.push(opts.sort); return { data: [makeReview()], nextPaginationToken: null }; };
+  await get('/api/apps/com.example.app/reviews?sort=helpful');
+  await get('/api/apps/com.example.app/reviews?sort=rated');
+  await get('/api/apps/com.example.app/reviews?sort=newest');
+  await get('/api/apps/com.example.app/reviews');
+  assert.deepEqual(captured, [SORT_HELPFUL, SORT_RATED, SORT_NEWEST, SORT_NEWEST]);
+  fake.reviews = async () => ({ data: [makeReview()], nextPaginationToken: null });
+});
+
+test('reviews rejects invalid sort and out-of-range num', async () => {
+  assert.equal((await get('/api/apps/com.example.app/reviews?sort=bogus')).status, 400);
+  assert.equal((await get('/api/apps/com.example.app/reviews?num=0')).status, 400);
+  assert.equal((await get('/api/apps/com.example.app/reviews?userdata=yes')).status, 400);
+});
+
+// ─── /developers/ ────────────────────────────────────────────────────────────
+
+test('developer apps returns devId plus cleaned apps', async () => {
+  const { status, body } = await get('/api/developers/Example%20Dev/');
+  assert.equal(status, 200);
+  assert.equal(body.devId, 'Example Dev');
+  assert.equal(body.apps[0].appId, 'com.example.app');
+  assert.match(body.apps[0].url, /\/api\/apps\/com\.example\.app$/);
+});
+
+test('developer list without devId returns 400 with example URL', async () => {
+  const { status, body } = await get('/api/developers/');
+  assert.equal(status, 400);
+  assert.match(body.message, /developer id/i);
+  assert.match(body.example, /\/api\/developers\/Wikimedia%20Foundation$/);
+});
+
+// ─── /lists/ ─────────────────────────────────────────────────────────────────
+
+test('lists requires category and collection', async () => {
+  const missing = await get('/api/lists/');
+  assert.equal(missing.status, 400);
+  assert.ok(missing.body.messages.some((m) => /category/.test(m)));
+  assert.ok(missing.body.messages.some((m) => /collection/.test(m)));
+});
+
+test('lists forwards category/collection to scraper list()', async () => {
+  let captured;
+  fake.list = async (opts) => { captured = opts; return [makeApp()]; };
+  const { status, body } = await get('/api/lists/?category=GAME&collection=TOP_SELLING&num=5');
+  assert.equal(status, 200);
+  assert.equal(captured.category, 'GAME');
+  assert.equal(captured.collection, 'TOP_SELLING');
+  assert.equal(captured.num, 5);
+  assert.equal(body.results.length, 1);
+  fake.list = async (opts) => Array.from({ length: opts.num || 60 }, (_, i) => makeApp(`com.example.app${i}`));
+});
+
+// ─── /categories/ and /collections/ ──────────────────────────────────────────
+
+test('categories returns scraper category keys', async () => {
+  const { status, body } = await get('/api/categories/');
+  assert.equal(status, 200);
+  assert.deepEqual(body, ['GAME', 'FINANCE']);
+});
+
+test('collections returns scraper collection keys', async () => {
+  const { status, body } = await get('/api/collections/');
+  assert.equal(status, 200);
+  assert.deepEqual(body, ['TOP_SELLING', 'TOP_GROSSING']);
+});
+
+// ─── error handler on /v2 ────────────────────────────────────────────────────
+
+test('v2 error handler emits problem+json', async () => {
+  fake.app = async () => { throw new Error('App not found (404)'); };
+  const { status, headers, body } = await get('/v2/apps/com.missing.app');
+  assert.equal(status, 404);
+  assert.match(headers.get('content-type'), /application\/problem\+json/);
+  assert.equal(body.title, 'Not Found');
+  assert.equal(body.status, 404);
+  assert.ok(body.instance.endsWith('/v2/apps/com.missing.app'));
+  fake.app = async () => makeApp();
+});

--- a/test/schemas.test.js
+++ b/test/schemas.test.js
@@ -1,0 +1,106 @@
+'use strict';
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  UpstreamSchemaDriftError,
+  validateApp,
+  validateAppList,
+  validateReviews,
+  validateDataSafety,
+  validatePermissions,
+  validateSuggest,
+  validateStringArray,
+  validateDeveloperApps
+} from '../lib/schemas.js';
+
+const validApp = { appId: 'com.foo', title: 'Foo', url: 'https://play.google.com/x' };
+
+test('validateApp accepts a minimal app and passes extra fields through', () => {
+  const data = { ...validApp, score: 4.2, extra: true };
+  const out = validateApp(data, '/v2/apps');
+  assert.equal(out.appId, 'com.foo');
+  assert.equal(out.extra, true);
+});
+
+test('validateApp throws UpstreamSchemaDriftError on missing fields', () => {
+  assert.throws(
+    () => validateApp({ title: 'no id' }, '/v2/apps'),
+    (err) => {
+      assert.ok(err instanceof UpstreamSchemaDriftError);
+      assert.equal(err.name, 'UpstreamSchemaDriftError');
+      assert.equal(err.code, 'UPSTREAM_SCHEMA_DRIFT');
+      assert.equal(err.statusCode, 502);
+      assert.ok(Array.isArray(err.issues));
+      assert.ok(err.issues.length > 0);
+      return true;
+    }
+  );
+});
+
+test('drift error issues are capped at 5', () => {
+  const bad = Array.from({ length: 10 }, (_, i) => ({ [`f${i}`]: i }));
+  try {
+    validateAppList({ results: bad }, '/v2/apps');
+    assert.fail('should have thrown');
+  } catch (err) {
+    assert.ok(err instanceof UpstreamSchemaDriftError);
+    assert.ok(err.issues.length <= 5);
+  }
+});
+
+test('validateAppList accepts wrapped results', () => {
+  const out = validateAppList({ results: [validApp] }, '/v2/apps');
+  assert.equal(out.results.length, 1);
+});
+
+test('validateAppList rejects non-array results', () => {
+  assert.throws(() => validateAppList({ results: 'nope' }, '/v2/apps'), UpstreamSchemaDriftError);
+});
+
+test('validateReviews accepts data + optional pagination token', () => {
+  const review = {
+    id: 'r1',
+    date: '2026-01-01',
+    score: 5,
+    title: null,
+    text: 'great',
+    thumbsUp: 3
+  };
+  const out = validateReviews({ results: { data: [review], nextPaginationToken: 'tok' } }, '/v2/reviews');
+  assert.equal(out.results.data.length, 1);
+  assert.equal(out.results.nextPaginationToken, 'tok');
+});
+
+test('validateReviews rejects malformed review entries', () => {
+  assert.throws(
+    () => validateReviews({ results: { data: [{ id: 'r1' }] } }, '/v2/reviews'),
+    UpstreamSchemaDriftError
+  );
+});
+
+test('validateDataSafety accepts object shape with optional arrays', () => {
+  const out = validateDataSafety({ sharedData: [], collectedData: [{ data: 'Location' }] }, '/v2/datasafety');
+  assert.equal(out.collectedData.length, 1);
+});
+
+test('validatePermissions accepts list wrapper with union type field', () => {
+  const out = validatePermissions({ results: [{ type: 'android.permission.CAMERA' }, { type: 1 }] }, '/v2/permissions');
+  assert.equal(out.results.length, 2);
+});
+
+test('validateSuggest accepts term/url items', () => {
+  const out = validateSuggest({ results: [{ term: 'chess', url: 'https://x' }] }, '/v2/suggest');
+  assert.equal(out.results[0].term, 'chess');
+});
+
+test('validateStringArray accepts plain string arrays', () => {
+  assert.deepEqual(validateStringArray(['GAME', 'SOCIAL'], '/v2/categories'), ['GAME', 'SOCIAL']);
+  assert.throws(() => validateStringArray([1, 2], '/v2/categories'), UpstreamSchemaDriftError);
+});
+
+test('validateDeveloperApps requires devId and apps array', () => {
+  const out = validateDeveloperApps({ devId: 'Foo Dev', apps: [validApp] }, '/v2/developers');
+  assert.equal(out.devId, 'Foo Dev');
+  assert.throws(() => validateDeveloperApps({ apps: [validApp] }, '/v2/developers'), UpstreamSchemaDriftError);
+});

--- a/test/urlUtils.test.js
+++ b/test/urlUtils.test.js
@@ -1,0 +1,49 @@
+'use strict';
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildUrl, cleanUrls } from '../lib/urlUtils.js';
+
+const mockReq = ({
+  protocol = 'https',
+  host = 'api.example.com',
+  baseUrl = '/api'
+} = {}) => ({
+  protocol,
+  baseUrl,
+  get: (name) => (name.toLowerCase() === 'host' ? host : undefined)
+});
+
+test('buildUrl joins protocol, host, baseUrl and subpath', () => {
+  assert.equal(buildUrl(mockReq(), 'apps/com.foo'), 'https://api.example.com/api/apps/com.foo');
+});
+
+test('buildUrl handles empty baseUrl', () => {
+  assert.equal(buildUrl(mockReq({ baseUrl: '' }), 'apps/com.foo'), 'https://api.example.com/apps/com.foo');
+});
+
+test('cleanUrls rewrites app URLs to API paths and preserves other fields', () => {
+  const app = {
+    appId: 'com.foo',
+    title: 'Foo',
+    url: 'https://play.google.com/store/apps/details?id=com.foo',
+    developer: 'Foo Dev & Co',
+    score: 4.5
+  };
+  const cleaned = cleanUrls(mockReq())(app);
+
+  assert.equal(cleaned.playstoreUrl, app.url);
+  assert.equal(cleaned.url, 'https://api.example.com/api/apps/com.foo');
+  assert.equal(cleaned.permissions, 'https://api.example.com/api/apps/com.foo/permissions');
+  assert.equal(cleaned.similar, 'https://api.example.com/api/apps/com.foo/similar');
+  assert.equal(cleaned.reviews, 'https://api.example.com/api/apps/com.foo/reviews');
+  assert.equal(cleaned.datasafety, 'https://api.example.com/api/apps/com.foo/datasafety');
+  assert.equal(cleaned.categories, 'https://api.example.com/api/categories/');
+  assert.equal(cleaned.score, 4.5);
+});
+
+test('cleanUrls encodes developer names in URLs', () => {
+  const cleaned = cleanUrls(mockReq())({ appId: 'com.foo', url: 'x', developer: 'Foo Dev & Co' });
+  assert.equal(cleaned.developer.devId, 'Foo Dev & Co');
+  assert.equal(cleaned.developer.url, 'https://api.example.com/api/developers/Foo%20Dev%20%26%20Co');
+});

--- a/v2-plan/DEFICIENCIES.md
+++ b/v2-plan/DEFICIENCIES.md
@@ -115,7 +115,16 @@
 | G6 | No license/commercialization note | legal | Repo is ISC; SaaS on top is fine. Add commercial terms page. |
 | G7 | CI lacks live smoke against staging | ops | Add scheduled Bruno smoke on deployed staging + alert (live-store smoke test exists locally). |
 
+## H. Test coverage & quality deficiencies
+
+| # | Atomic issue | Type | Notes |
+|---|-------------|------|-------|
+| H1 | No unit tests for `lib/` or `server.js`; coverage not enforced | debt | Add node:test unit suite (mocked scraper) + c8 coverage in CI. Baseline: lib/index.js 97%, logger.js 70%, server.js 0% (untestable — calls `app.listen()` at import). Extract `createApp()` factory. |
+| H2 | Unknown routes return 500 instead of 404 | bug | Catchall sets `err.status = 404` but `getErrorStatusCode()` never reads `.status`; message `'Not Found'` fails the lowercase `'not found'` check. Verified live: `GET /definitely-not-a-route` → 500 problem+json. Fix: honor `err.status`/`err.statusCode` in `getErrorStatusCode`. |
+
 ---
+
+## Suggested v2 milestone slicing (draft, pending answers)---
 
 ## Suggested v2 milestone slicing (draft, pending answers)
 


### PR DESCRIPTION
## H1: Unit test suite + coverage enforcement

Adds a fast, offline unit test suite for the `lib/` modules and wires coverage into CI.

### What's added
- **`test/*.test.js`** — node:test unit suites for `constants`, `errors`, `schemas`, `urlUtils`, and `index` (route handlers). The scraper is mocked via `--experimental-test-module-mocks` so tests run offline and deterministically.
- **`test:unit`** script — runs the unit suite with spec + JUnit reporters.
- **`test:unit:coverage`** — c8 coverage over the unit suite.
- **`test:coverage`** — now runs unit tests + E2E under c8 with `--all --include=lib --include=server.js` so `server.js` is measured.
- **`pretest`** — runs the unit suite before the E2E `npm test`.
- **CI** — `deploy-v2dev.yml` validate job now runs `test:coverage` and publishes the coverage table to the step summary + artifact.

### Coverage (unit suite)
| File | Stmts | Branch | Funcs | Lines |
|------|-------|--------|-------|-------|
| constants.js | 100% | 100% | 100% | 100% |
| errors.js | 100% | 100% | 100% | 100% |
| schemas.js | 100% | 100% | 100% | 100% |
| urlUtils.js | 100% | 100% | 100% | 100% |
| index.js | 97% | 85% | 100% | 97% |
| logger.js | 71% | 50% | 100% | 71% |

Remaining gaps are the pino-pretty transport branch (logger) and a few defensive catch blocks (index) — tracked separately.

Closes #168