### PR TITLE
B2: Country availability endpoint (#117)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,13 @@ curl "http://localhost:3000/api/collections/"
 curl "http://localhost:3000/api/lists/?collection=TOP_FREE&category=PRODUCTIVITY"
 ```
 
+### Country Availability
+
+```bash
+# Check which storefronts carry an app (comma-separated ISO-2 codes, max 30)
+curl "http://localhost:3000/api/apps/com.tencent.mm/availability?countries=IN,US,GB"
+```
+
 ### Data Safety and Permissions
 
 ```bash

--- a/bruno/GPlayAPIUnitTests/App/Get App Availability - Region Lock.bru
+++ b/bruno/GPlayAPIUnitTests/App/Get App Availability - Region Lock.bru
@@ -1,0 +1,32 @@
+meta {
+  name: Get App Availability - Region Lock
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{HOST}}/api/apps/com.tencent.mm/availability?countries=IN,US
+  body: none
+  auth: none
+}
+
+tests {
+  const responseData = res.getBody();
+
+  test("Status code is 200", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+
+  test("appId matches the requested app", function() {
+    expect(responseData.appId).to.equal("com.tencent.mm");
+  });
+
+  test("WeChat is unavailable in the IN storefront", function() {
+    expect(responseData.countries.IN.available).to.equal(false);
+    expect(responseData.countries.IN.status).to.equal("unavailable");
+  });
+
+  test("WeChat is available in the US storefront", function() {
+    expect(responseData.countries.US.available).to.equal(true);
+  });
+}

--- a/docs/endpoints.html
+++ b/docs/endpoints.html
@@ -36,6 +36,7 @@
       <tr><td>GET</td><td><code>/api/apps/:appId/similar?lang=&amp;country=</code></td><td>Similar apps</td></tr>
       <tr><td>GET</td><td><code>/api/apps/:appId/datasafety</code></td><td>Data safety labels</td></tr>
       <tr><td>GET</td><td><code>/api/apps/:appId/permissions</code></td><td>Permissions list</td></tr>
+      <tr><td>GET</td><td><code>/api/apps/:appId/availability?countries=IN,US</code></td><td>Country availability (max 30 codes)</td></tr>
       <tr><td>GET</td><td><code>/api/apps/:appId/reviews?sort=&amp;num=&amp;lang=</code></td><td>App reviews</td></tr>
     </table>
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -13,6 +13,9 @@ export const MAX_START = 500;
 // @mradex77/google-play-scraper caps list() at 200 results and has no start offset
 export const MAX_LIST_RESULTS = 200;
 
+// Availability endpoint: one upstream request per country — cap the fan-out
+export const MAX_AVAILABILITY_COUNTRIES = 30;
+
 // Reviews defaults
 export const DEFAULT_REVIEWS_COUNT = 100;
 export const MAX_REVIEWS_COUNT = 500;

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@ import {
   MAX_PAGE_SIZE,
   DEFAULT_START,
   MAX_LIST_RESULTS,
+  MAX_AVAILABILITY_COUNTRIES,
   DEFAULT_REVIEWS_COUNT,
   MAX_REVIEWS_COUNT,
   SORT_HELPFUL,
@@ -29,7 +30,8 @@ import {
   validatePermissions,
   validateSuggest,
   validateStringArray,
-  validateDeveloperApps
+  validateDeveloperApps,
+  validateAvailability
 } from './schemas.js';
 
 const router = Express.Router();
@@ -243,6 +245,62 @@ router.get('/apps/:appId/permissions',
         return { results: perms };
       })
       .then(d => validatePermissions(d, '/apps/:appId/permissions'))
+      .then(res.json.bind(res))
+      .catch(next);
+  });
+
+/* Country availability */
+router.get('/apps/:appId/availability',
+  param('appId').isString().trim().isLength({ min: 1 }).withMessage('appId is required'),
+  query('countries').exists().withMessage('countries parameter is required (comma-separated ISO 3166-1 alpha-2 codes, e.g. countries=IN,US,GB)'),
+  handleValidationErrors,
+  function (req, res, next) {
+    const codes = req.query.countries
+      .split(',')
+      .map((code) => code.trim().toUpperCase())
+      .filter((code) => code.length > 0);
+
+    const badCodes = codes.filter((code) => !COUNTRY_CODE_RE.test(code));
+    if (badCodes.length > 0) {
+      const error = new Error(`countries must be comma-separated ISO 3166-1 alpha-2 codes; invalid: ${badCodes.join(', ')}`);
+      error.code = 'VALIDATION_ERROR';
+      if (req.baseUrl === '/v2') {
+        return res.status(400).type('application/problem+json').json(problemDetails(error, req, 400));
+      }
+      return res.status(400).json({ error: 'Validation failed', messages: [error.message] });
+    }
+
+    if (codes.length === 0) {
+      const error = new Error('countries must contain at least one ISO 3166-1 alpha-2 code');
+      error.code = 'VALIDATION_ERROR';
+      if (req.baseUrl === '/v2') {
+        return res.status(400).type('application/problem+json').json(problemDetails(error, req, 400));
+      }
+      return res.status(400).json({ error: 'Validation failed', messages: [error.message] });
+    }
+
+    if (codes.length > MAX_AVAILABILITY_COUNTRIES) {
+      const error = new Error(`countries supports at most ${MAX_AVAILABILITY_COUNTRIES} codes per request (got ${codes.length})`);
+      error.code = 'VALIDATION_ERROR';
+      if (req.baseUrl === '/v2') {
+        return res.status(400).type('application/problem+json').json(problemDetails(error, req, 400));
+      }
+      return res.status(400).json({ error: 'Validation failed', messages: [error.message] });
+    }
+
+    gplay.availability({ appId: req.params.appId, countries: codes })
+      .then((result) => validateAvailability(result, '/apps/:appId/availability'))
+      .then((result) => {
+        const countries = {};
+        for (const [code, entry] of Object.entries(result.countries)) {
+          countries[code.toUpperCase()] = {
+            available: entry.status === 'available',
+            status: entry.status,
+            ...(entry.message !== undefined ? { message: entry.message } : {})
+          };
+        }
+        return { appId: result.appId, countries };
+      })
       .then(res.json.bind(res))
       .catch(next);
   });

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -105,6 +105,19 @@ export const validatePermissions = (data, endpoint) => validate(ListWrapper(Perm
 export const validateSuggest = (data, endpoint) => validate(ListWrapper(SuggestItemSchema), data, endpoint);
 export const validateStringArray = (data, endpoint) => validate(StringArraySchema, data, endpoint);
 
+// Availability response: { appId, countries: { CC: { status, message? } } }
+const CountryAvailabilitySchema = z.object({
+  status: z.enum(['available', 'unavailable', 'error']),
+  message: z.string().optional()
+}).passthrough();
+
+const AvailabilitySchema = z.object({
+  appId: z.string(),
+  countries: z.record(z.string(), CountryAvailabilitySchema)
+});
+
+export const validateAvailability = (data, endpoint) => validate(AvailabilitySchema, data, endpoint);
+
 // Developer apps response: { devId, apps: [...] }
 const DeveloperAppsSchema = z.object({
   devId: z.string(),

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -58,7 +58,14 @@ const fake = {
     { type: 7, permissions: ['Unknown group'] }
   ],
   reviews: async () => ({ data: [makeReview()], nextPaginationToken: null }),
-  developer: async () => [makeApp()]
+  developer: async () => [makeApp()],
+  availability: async (opts) => ({
+    appId: opts.appId,
+    countries: Object.fromEntries(opts.countries.map((code, i) => [
+      code,
+      i === 0 ? { status: 'available' } : i === 1 ? { status: 'unavailable' } : { status: 'error', message: 'storefront fetch failed' }
+    ]))
+  })
 };
 
 mock.module('@mradex77/google-play-scraper', {
@@ -394,6 +401,64 @@ test('collections returns scraper collection keys', async () => {
   const { status, body } = await get('/api/collections/');
   assert.equal(status, 200);
   assert.deepEqual(body, ['TOP_SELLING', 'TOP_GROSSING']);
+});
+
+// ─── B2: country availability on /apps/:appId/availability ──────────────────
+
+test('availability forwards appId and parsed country codes to scraper', async () => {
+  let captured;
+  const originalAvailability = fake.availability;
+  fake.availability = async (opts) => { captured = opts; return { appId: opts.appId, countries: { US: { status: 'available' } } }; };
+  const { status } = await get('/api/apps/com.example.app/availability?countries=in, us ,GB');
+  assert.equal(status, 200);
+  assert.equal(captured.appId, 'com.example.app');
+  assert.deepEqual(captured.countries, ['IN', 'US', 'GB']);
+  fake.availability = originalAvailability;
+});
+
+test('availability maps statuses to available booleans and keeps error messages', async () => {
+  const { status, body } = await get('/api/apps/com.example.app/availability?countries=IN,US,DE');
+  assert.equal(status, 200);
+  assert.equal(body.appId, 'com.example.app');
+  assert.deepEqual(body.countries.IN, { available: true, status: 'available' });
+  assert.deepEqual(body.countries.US, { available: false, status: 'unavailable' });
+  assert.equal(body.countries.DE.available, false);
+  assert.equal(body.countries.DE.status, 'error');
+  assert.equal(body.countries.DE.message, 'storefront fetch failed');
+});
+
+test('availability rejects invalid country codes (v1 shape)', async () => {
+  const { status, body } = await get('/api/apps/com.example.app/availability?countries=IN,USA');
+  assert.equal(status, 400);
+  assert.equal(body.error, 'Validation failed');
+  assert.match(body.messages[0], /USA/);
+});
+
+test('availability rejects invalid country codes with problem+json on /v2', async () => {
+  const { status, headers, body } = await get('/v2/apps/com.example.app/availability?countries=ZZZ');
+  assert.equal(status, 400);
+  assert.match(headers.get('content-type'), /application\/problem\+json/);
+  assert.equal(body.status, 400);
+  assert.match(body.detail, /ZZZ/);
+});
+
+test('availability requires the countries parameter', async () => {
+  const { status, body } = await get('/api/apps/com.example.app/availability');
+  assert.equal(status, 400);
+  assert.match(body.messages[0], /countries/);
+});
+
+test('availability rejects an empty countries list', async () => {
+  const { status, body } = await get('/api/apps/com.example.app/availability?countries=,,');
+  assert.equal(status, 400);
+  assert.match(body.messages[0], /at least one/);
+});
+
+test('availability rejects more than 30 countries', async () => {
+  const many = Array.from({ length: 31 }, (_, i) => String.fromCharCode(65 + Math.floor(i / 26), 65 + (i % 26))).join(',');
+  const { status, body } = await get(`/api/apps/com.example.app/availability?countries=${many}`);
+  assert.equal(status, 400);
+  assert.match(body.messages[0], /at most 30/);
 });
 
 // ─── error handler on /v2 ────────────────────────────────────────────────────

--- a/v2-plan/DEFICIENCIES.md
+++ b/v2-plan/DEFICIENCIES.md
@@ -37,7 +37,7 @@
 | # | Atomic issue | Type | Notes |
 |---|-------------|------|-------|
 | B1 | No batch app-details endpoint | feature | Scraper has `apps({ appIds, concurrency })`. Add `POST /api/apps/batch` (or `GET ?ids=a,b,c`). High-value for credit system (1 call = N credits). |
-| B2 | No country-availability endpoint | feature | Scraper `availability({ appId, countries })` → available/unavailable/error per storefront. Add `GET /api/apps/:appId/availability?countries=IN,US,...`. |
+| B2 | ✅ Fixed — `GET /apps/:appId/availability?countries=` | feature | Shipped: comma-separated ISO-2 codes, max 30, maps scraper statuses to `{available, status, message?}`. |
 | B3 | No streaming/bulk reviews export | feature | Scraper `reviewsAll` / `reviewsIterator`. Add `GET /api/apps/:appId/reviews/export` (NDJSON or CSV stream) as a premium-credit endpoint. |
 | B4 | No search/developer iterators exposed | feature | Scraper `searchIterator`, `developerIterator` for >200 results. Add cursor-paginated `GET /api/apps/search/all`. |
 | B5 | `suggest` buried as `?suggest=` query param on `/apps/` | refactor | Promote to `GET /api/suggest?q=`. Keep legacy param with deprecation header. |


### PR DESCRIPTION
## Summary
- `GET /api|v2/apps/:appId/availability?countries=IN,US,GB` — per-storefront availability probe backed by scraper `availability()`.
- Comma-separated ISO 3166-1 alpha-2 codes (uppercased, whitespace-tolerated), max **30** codes per request → 400 beyond that.
- Response maps scraper statuses to `{available: boolean, status, message?}` with uppercase keys matching input.
- Zod validation of upstream response → 502 problem+json on drift.

## Tests
- 7 unit tests (parsing, mapping, v1/v2 error shapes, 30-cap).
- Bruno: happy path + **region-lock assertion** — WeChat `com.tencent.mm` is `unavailable` in IN and `available` in US (verified live).
- Full suite: unit 33/33, full API 70/70, `npm run test:unit` 82/82, lint clean.

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)