### PR TITLE
B1: Batch app details endpoint POST /apps/batch (#116)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,16 @@ curl "http://localhost:3000/api/lists/?collection=TOP_FREE&category=PRODUCTIVITY
 curl "http://localhost:3000/api/apps/com.tencent.mm/availability?countries=IN,US,GB"
 ```
 
+### Batch App Details
+
+```bash
+# Fetch details for up to 20 apps in one call (POST JSON body)
+# Optional: concurrency (1-20), ?fields= for sparse responses, ?country=/?lang=
+curl -X POST "http://localhost:3000/api/apps/batch" \
+  -H "Content-Type: application/json" \
+  -d '{"appIds": ["in.juspay.nammayatri", "com.duolingo"], "concurrency": 2}'
+```
+
 ### Data Safety and Permissions
 
 ```bash

--- a/bruno/GPlayAPIUnitTests/App Batch/Batch App Details - Over Cap.bru
+++ b/bruno/GPlayAPIUnitTests/App Batch/Batch App Details - Over Cap.bru
@@ -1,0 +1,39 @@
+meta {
+  name: Batch App Details - Over Cap
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{HOST}}/api/apps/batch
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "appIds": [
+      "com.example.app0", "com.example.app1", "com.example.app2", "com.example.app3", "com.example.app4",
+      "com.example.app5", "com.example.app6", "com.example.app7", "com.example.app8", "com.example.app9",
+      "com.example.app10", "com.example.app11", "com.example.app12", "com.example.app13", "com.example.app14",
+      "com.example.app15", "com.example.app16", "com.example.app17", "com.example.app18", "com.example.app19",
+      "com.example.app20"
+    ]
+  }
+}
+
+vars:pre-request {
+  expectedResponseStatusCode: 400
+}
+
+tests {
+  const responseData = res.getBody();
+
+  test("Status code is 400", function() {
+    expect(res.getStatus()).to.equal(400);
+  });
+
+  test("Error message states the 20-app cap", function() {
+    expect(responseData.messages[0]).to.include("at most 20");
+  });
+}

--- a/bruno/GPlayAPIUnitTests/App Batch/Batch App Details.bru
+++ b/bruno/GPlayAPIUnitTests/App Batch/Batch App Details.bru
@@ -1,0 +1,38 @@
+meta {
+  name: Batch App Details
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{HOST}}/api/apps/batch
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "appIds": ["in.juspay.nammayatri", "com.duolingo"],
+    "concurrency": 2
+  }
+}
+
+tests {
+  const responseData = res.getBody();
+
+  test("Status code is 200", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+
+  test("One settled entry per requested appId, in request order", function() {
+    expect(responseData.results.length).to.equal(2);
+    expect(responseData.results[0].appId).to.equal("in.juspay.nammayatri");
+    expect(responseData.results[1].appId).to.equal("com.duolingo");
+  });
+
+  test("Known apps come back fulfilled with app details", function() {
+    expect(responseData.results[0].status).to.equal("fulfilled");
+    expect(responseData.results[0].app.appId).to.equal("in.juspay.nammayatri");
+    expect(responseData.results[0].app.title).to.be.a("string");
+  });
+}

--- a/docs/endpoints.html
+++ b/docs/endpoints.html
@@ -37,6 +37,7 @@
       <tr><td>GET</td><td><code>/api/apps/:appId/datasafety</code></td><td>Data safety labels</td></tr>
       <tr><td>GET</td><td><code>/api/apps/:appId/permissions</code></td><td>Permissions list</td></tr>
       <tr><td>GET</td><td><code>/api/apps/:appId/availability?countries=IN,US</code></td><td>Country availability (max 30 codes)</td></tr>
+      <tr><td>POST</td><td><code>/api/apps/batch</code> (body: <code>{"appIds": [...], "concurrency": 1-20}</code>)</td><td>Batch app details (max 20 apps, per-app settled results)</td></tr>
       <tr><td>GET</td><td><code>/api/apps/:appId/reviews?sort=&amp;num=&amp;lang=</code></td><td>App reviews</td></tr>
     </table>
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -13,6 +13,10 @@ export const MAX_START = 500;
 // @mradex77/google-play-scraper caps list() at 200 results and has no start offset
 export const MAX_LIST_RESULTS = 200;
 
+// Batch app-details (POST /apps/batch) — scraper bound, plus a cost guard
+export const MAX_BATCH_APPS = 20;
+export const MAX_BATCH_CONCURRENCY = 20;
+
 // Availability endpoint: one upstream request per country — cap the fan-out
 export const MAX_AVAILABILITY_COUNTRIES = 30;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,11 +3,13 @@
 import Express from 'express';
 import gplay from '@mradex77/google-play-scraper';
 import qs from 'querystring';
-import { query, param, validationResult } from 'express-validator';
+import { query, param, body, validationResult } from 'express-validator';
 import {
   MAX_PAGE_SIZE,
   DEFAULT_START,
   MAX_LIST_RESULTS,
+  MAX_BATCH_APPS,
+  MAX_BATCH_CONCURRENCY,
   MAX_AVAILABILITY_COUNTRIES,
   DEFAULT_REVIEWS_COUNT,
   MAX_REVIEWS_COUNT,
@@ -32,7 +34,8 @@ import {
   validateSuggest,
   validateStringArray,
   validateDeveloperApps,
-  validateAvailability
+  validateAvailability,
+  validateBatch
 } from './schemas.js';
 
 const router = Express.Router();
@@ -210,6 +213,70 @@ router.get('/apps/:appId',
       .then(cleanUrls(req))
       .then(d => validateApp(d, '/apps/:appId'))
       .then(d => (projection ? projectFields(d, projection) : d))
+      .then(res.json.bind(res))
+      .catch(next);
+  });
+
+/* Batch app details */
+router.post('/apps/batch',
+  body('appIds').exists().withMessage('appIds is required (array of app IDs, e.g. ["com.duolingo","com.spotify.music"])'),
+  body('appIds').isArray().withMessage('appIds must be an array of app IDs'),
+  body('appIds').notEmpty().withMessage('appIds must contain at least one app ID'),
+  body('appIds.*').isString().trim().isLength({ min: 1 }).withMessage('appIds entries must be non-empty strings'),
+  body('concurrency').optional().isInt({ min: 1, max: MAX_BATCH_CONCURRENCY }).withMessage(`concurrency must be between 1 and ${MAX_BATCH_CONCURRENCY}`),
+  query('fields').optional().isString().trim().isLength({ min: 1 }).withMessage('fields must be a comma-separated list of field names'),
+  handleValidationErrors,
+  function (req, res, next) {
+    let projection = null;
+    if (req.query.fields) {
+      const parsed = parseFields(req.query.fields);
+      if (parsed.error) {
+        const error = new Error(parsed.error);
+        error.code = 'VALIDATION_ERROR';
+        if (req.baseUrl === '/v2') {
+          return res.status(400).type('application/problem+json').json(problemDetails(error, req, 400));
+        }
+        return res.status(400).json({ error: 'Validation failed', messages: [parsed.error] });
+      }
+      projection = parsed.fields;
+    }
+
+    const appIds = [...new Set(req.body.appIds.map((id) => id.trim()))];
+    if (appIds.length === 0) {
+      const error = new Error('appIds must contain at least one app ID');
+      error.code = 'VALIDATION_ERROR';
+      if (req.baseUrl === '/v2') {
+        return res.status(400).type('application/problem+json').json(problemDetails(error, req, 400));
+      }
+      return res.status(400).json({ error: 'Validation failed', messages: [error.message] });
+    }
+    if (appIds.length > MAX_BATCH_APPS) {
+      const error = new Error(`appIds supports at most ${MAX_BATCH_APPS} apps per request (got ${req.body.appIds.length})`);
+      error.code = 'VALIDATION_ERROR';
+      if (req.baseUrl === '/v2') {
+        return res.status(400).type('application/problem+json').json(problemDetails(error, req, 400));
+      }
+      return res.status(400).json({ error: 'Validation failed', messages: [error.message] });
+    }
+
+    gplay.apps({
+      appIds,
+      concurrency: req.body.concurrency ? parseInt(req.body.concurrency, 10) : undefined,
+      country: req.query.country,
+      lang: req.query.lang
+    })
+      .then((settled) => settled.map((entry) => entry.status === 'fulfilled'
+        ? { appId: entry.appId, status: entry.status, app: cleanUrls(req)(entry.app) }
+        : { appId: entry.appId, status: entry.status, error: entry.error?.message ?? String(entry.error) }))
+      .then(toList)
+      .then(d => validateBatch(d, '/apps/batch'))
+      .then((d) => {
+        if (!projection) return d;
+        d.results = d.results.map((entry) => entry.status === 'fulfilled'
+          ? { ...entry, app: projectFields(entry.app, projection) }
+          : entry);
+        return d;
+      })
       .then(res.json.bind(res))
       .catch(next);
   });
@@ -480,4 +547,5 @@ function errorHandler (err, req, res, _next) {
 
 router.use(errorHandler);
 
+export { errorHandler };
 export default router;

--- a/lib/schemas.js
+++ b/lib/schemas.js
@@ -125,3 +125,22 @@ const DeveloperAppsSchema = z.object({
 }).passthrough();
 
 export const validateDeveloperApps = (data, endpoint) => validate(DeveloperAppsSchema, data, endpoint);
+
+// Batch app details response: { results: [{ appId, status: 'fulfilled', app } | { appId, status: 'rejected', error }] }
+// Mirrors Promise.allSettled shape returned by @mradex77/google-play-scraper apps().
+const BatchSettledSchema = z.discriminatedUnion('status', [
+  z.object({
+    appId: z.string(),
+    status: z.literal('fulfilled'),
+    app: AppSchema
+  }),
+  z.object({
+    appId: z.string(),
+    status: z.literal('rejected'),
+    error: z.string()
+  })
+]);
+
+const BatchSchema = ListWrapper(BatchSettledSchema);
+
+export const validateBatch = (data, endpoint) => validate(BatchSchema, data, endpoint);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -65,7 +65,10 @@ const fake = {
       code,
       i === 0 ? { status: 'available' } : i === 1 ? { status: 'unavailable' } : { status: 'error', message: 'storefront fetch failed' }
     ]))
-  })
+  }),
+  apps: async (opts) => opts.appIds.map((appId) => appId === 'com.example.missing'
+    ? { appId, status: 'rejected', error: { message: 'App not found (404)' } }
+    : { appId, status: 'fulfilled', app: makeApp(appId) })
 };
 
 mock.module('@mradex77/google-play-scraper', {
@@ -73,13 +76,15 @@ mock.module('@mradex77/google-play-scraper', {
   defaultExport: fake
 });
 
-const { default: router } = await import('../lib/index.js');
+const { default: router, errorHandler } = await import('../lib/index.js');
 
 // ─── Test server ─────────────────────────────────────────────────────────────
 
 const app = Express();
+app.use(Express.json());
 app.use('/api', router);
 app.use('/v2', router);
+app.use(errorHandler);
 
 let server;
 let base;
@@ -92,6 +97,18 @@ before(async () => {
 });
 
 after(() => new Promise((resolve) => server.close(resolve)));
+
+const post = async (path, payload) => {
+  const res = await fetch(base + path, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  const text = await res.text();
+  let body = null;
+  try { body = JSON.parse(text); } catch { /* non-JSON */ }
+  return { status: res.status, headers: res.headers, body };
+};
 
 const get = async (path) => {
   const res = await fetch(base + path);
@@ -401,6 +418,83 @@ test('collections returns scraper collection keys', async () => {
   const { status, body } = await get('/api/collections/');
   assert.equal(status, 200);
   assert.deepEqual(body, ['TOP_SELLING', 'TOP_GROSSING']);
+});
+
+// ─── B1: batch app details on POST /apps/batch ──────────────────────────────
+
+test('batch returns one settled entry per appId, in order', async () => {
+  const { status, body } = await post('/api/apps/batch', { appIds: ['com.example.one', 'com.example.two', 'com.example.missing'] });
+  assert.equal(status, 200);
+  assert.equal(body.results.length, 3);
+  assert.deepEqual(body.results.map((r) => r.appId), ['com.example.one', 'com.example.two', 'com.example.missing']);
+  assert.equal(body.results[0].status, 'fulfilled');
+  assert.equal(body.results[0].app.appId, 'com.example.one');
+  assert.equal(body.results[2].status, 'rejected');
+  assert.equal(body.results[2].app, undefined);
+  assert.equal(body.results[2].error, 'App not found (404)');
+});
+
+test('batch forwards country/lang/concurrency to scraper', async () => {
+  let captured;
+  const original = fake.apps;
+  fake.apps = async (opts) => { captured = opts; return original(opts); };
+  const { status } = await post('/api/apps/batch?country=US&lang=en', { appIds: ['com.example.app'], concurrency: 4 });
+  assert.equal(status, 200);
+  assert.deepEqual(captured.appIds, ['com.example.app']);
+  assert.equal(captured.country, 'US');
+  assert.equal(captured.lang, 'en');
+  assert.equal(captured.concurrency, 4);
+  fake.apps = original;
+});
+
+test('batch rejects a missing appIds array', async () => {
+  const { status, body } = await post('/api/apps/batch', {});
+  assert.equal(status, 400);
+  assert.equal(body.error, 'Validation failed');
+});
+
+test('batch rejects a non-array appIds', async () => {
+  const { status, body } = await post('/api/apps/batch', { appIds: 'com.example.app' });
+  assert.equal(status, 400);
+  assert.match(body.messages[0], /appIds must be an array/);
+});
+
+test('batch rejects an empty appIds array', async () => {
+  const { status, body } = await post('/api/apps/batch', { appIds: [] });
+  assert.equal(status, 400);
+  assert.match(body.messages[0], /at least one/);
+});
+
+test('batch rejects more than 20 appIds', async () => {
+  const appIds = Array.from({ length: 21 }, (_, i) => `com.example.app${i}`);
+  const { status, body } = await post('/api/apps/batch', { appIds });
+  assert.equal(status, 400);
+  assert.match(body.messages[0], /at most 20/);
+});
+
+test('batch rejects invalid concurrency', async () => {
+  const { status, body } = await post('/api/apps/batch', { appIds: ['com.example.app'], concurrency: 21 });
+  assert.equal(status, 400);
+  assert.match(body.messages[0], /concurrency/);
+});
+
+test('batch rejects invalid fields with problem+json on /v2', async () => {
+  const { status, headers, body } = await post('/v2/apps/batch?fields=bogus', { appIds: ['com.example.app'] });
+  assert.equal(status, 400);
+  assert.match(headers.get('content-type'), /application\/problem\+json/);
+  assert.match(body.detail, /unknown field/i);
+});
+
+test('batch applies fields projection to fulfilled apps only', async () => {
+  const { status, body } = await post('/api/apps/batch?fields=appId,title', { appIds: ['com.example.app', 'com.example.missing'] });
+  assert.equal(status, 200);
+  assert.deepEqual(Object.keys(body.results[0].app).sort(), ['appId', 'title']);
+  assert.equal(body.results[1].status, 'rejected');
+});
+
+test('batch rejects malformed JSON body', async () => {
+  const res = await fetch(base + '/api/apps/batch', { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{oops' });
+  assert.equal(res.status, 400);
 });
 
 // ─── B2: country availability on /apps/:appId/availability ──────────────────

--- a/v2-plan/DEFICIENCIES.md
+++ b/v2-plan/DEFICIENCIES.md
@@ -36,7 +36,7 @@
 
 | # | Atomic issue | Type | Notes |
 |---|-------------|------|-------|
-| B1 | No batch app-details endpoint | feature | Scraper has `apps({ appIds, concurrency })`. Add `POST /api/apps/batch` (or `GET ?ids=a,b,c`). High-value for credit system (1 call = N credits). |
+| B1 | ✅ Fixed — `POST /apps/batch` | feature | Shipped: JSON body `{appIds: [...]}` (max 20, deduped), optional `concurrency` 1-20 and `?fields=` projection. Returns settled entries in request order; per-app failures are reported, not fatal. |
 | B2 | ✅ Fixed — `GET /apps/:appId/availability?countries=` | feature | Shipped: comma-separated ISO-2 codes, max 30, maps scraper statuses to `{available, status, message?}`. |
 | B3 | No streaming/bulk reviews export | feature | Scraper `reviewsAll` / `reviewsIterator`. Add `GET /api/apps/:appId/reviews/export` (NDJSON or CSV stream) as a premium-credit endpoint. |
 | B4 | No search/developer iterators exposed | feature | Scraper `searchIterator`, `developerIterator` for >200 results. Add cursor-paginated `GET /api/apps/search/all`. |


### PR DESCRIPTION
## What
- `POST /api/apps/batch` (mounted on `/v2` too): fetch up to **20** app details in one call
- JSON body `{appIds: [...], concurrency?}` — appIds deduped + trimmed, concurrency capped 1–20 (scraper default 5)
- Response `{results: [{appId, status: 'fulfilled', app} | {appId, status: 'rejected', error: '...'}]}` in request order — per-app failures reported, never fatal
- Optional `?fields=` sparse projection reuses the B8 fields module
- `validateBatch` zod boundary schema → upstream drift surfaces as 502 with diagnostics
- v1/v2 error contract preserved (problem+json on /v2)

## Verification
- `npx eslint .` ✅ clean
- `npm audit --omit=dev --audit-level=high` ✅ 0 vulnerabilities
- `npm run test:unit` ✅ 99/99 (10 new batch cases)
- `npm test` (Bruno E2E, live Play Store): unit collection 49/49 ✅, full collection 70/70 ✅ incl. new `App Batch` happy-path + over-cap cases

## Docs
README section, `docs/endpoints.html` row, DEFICIENCIES B1 row → ✅ Fixed

Closes #116