### PR TITLE
feat(suggest): promote suggest to GET /suggest with legacy deprecation header (#118)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,16 @@ curl -X POST "http://localhost:3000/api/apps/batch" \
   -d '{"appIds": ["in.juspay.nammayatri", "com.duolingo"], "concurrency": 2}'
 ```
 
+### Search Suggest
+
+```bash
+# Autocomplete suggestions for a search term (GET /suggest)
+curl "http://localhost:3000/api/suggest?q=spot"
+
+# Legacy form (still works, sends a Deprecation header on /api)
+curl "http://localhost:3000/api/apps/?suggest=spot"
+```
+
 ### Data Safety and Permissions
 
 ```bash

--- a/bruno/GPlayAPIUnitTests/Suggest/Get Suggest - Missing q (400 Bad Request).bru
+++ b/bruno/GPlayAPIUnitTests/Suggest/Get Suggest - Missing q (400 Bad Request).bru
@@ -1,0 +1,28 @@
+meta {
+  name: Get Suggest - Missing q (400 Bad Request)
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{HOST}}/api/suggest
+  body: none
+  auth: none
+}
+
+vars:pre-request {
+  expectedResponseStatusCode: 400
+}
+
+tests {
+  const responseData = res.getBody();
+
+  test("Status code is 400", function() {
+    expect(res.getStatus()).to.equal(400);
+  });
+
+  test("Error message says q is required", function() {
+    expect(responseData.messages.join(" ")).to.include("q is required");
+  });
+
+}

--- a/bruno/GPlayAPIUnitTests/Suggest/Get Suggest.bru
+++ b/bruno/GPlayAPIUnitTests/Suggest/Get Suggest.bru
@@ -1,0 +1,36 @@
+meta {
+  name: Get Suggest
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{HOST}}/api/suggest?q=spot
+  body: none
+  auth: none
+}
+
+vars:pre-request {
+  expectedResponseStatusCode: 200
+}
+
+tests {
+  const responseData = res.getBody();
+
+  test("Status code is 200", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+
+  test("Returns a results array of suggestions", function() {
+    expect(responseData.results).to.be.an("array");
+    expect(responseData.results.length).to.be.at.least(1);
+  });
+
+  test("Each suggestion has term and search url", function() {
+    responseData.results.forEach((item) => {
+      expect(item.term).to.be.a("string");
+      expect(item.url).to.include("/apps/?q=");
+    });
+  });
+
+}

--- a/bruno/GPlayAPIUnitTests/Suggest/Legacy Suggest Param - Deprecation Header.bru
+++ b/bruno/GPlayAPIUnitTests/Suggest/Legacy Suggest Param - Deprecation Header.bru
@@ -1,0 +1,42 @@
+meta {
+  name: Legacy Suggest Param - Deprecation Header
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{HOST}}/api/apps/?suggest=spot
+  body: none
+  auth: none
+}
+
+vars:pre-request {
+  expectedResponseStatusCode: 200
+}
+
+tests {
+  const headers = res.headers;
+  const responseData = res.getBody();
+
+  test("Status code is 200", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+
+  test("Legacy param still returns suggestions", function() {
+    expect(responseData.results.length).to.be.at.least(1);
+  });
+
+  test("Deprecation header is set on v1", function() {
+    expect(headers["deprecation"]).to.equal("true");
+  });
+
+  test("Link header points at the promoted /suggest endpoint", function() {
+    const link = headers["link"];
+    expect(link).to.include("/api/suggest");
+    expect(link).to.include('rel="alternate"');
+  });
+
+  test("Status code matches expectedResponseStatusCode", function() {
+    expect(res.getStatus()).to.equal(200);
+  });
+}

--- a/docs/endpoints.html
+++ b/docs/endpoints.html
@@ -38,7 +38,8 @@
       <tr><td>GET</td><td><code>/api/apps/:appId/permissions</code></td><td>Permissions list</td></tr>
       <tr><td>GET</td><td><code>/api/apps/:appId/availability?countries=IN,US</code></td><td>Country availability (max 30 codes)</td></tr>
       <tr><td>POST</td><td><code>/api/apps/batch</code> (body: <code>{"appIds": [...], "concurrency": 1-20}</code>)</td><td>Batch app details (max 20 apps, per-app settled results)</td></tr>
-      <tr><td>GET</td><td><code>/api/apps/:appId/reviews?sort=&amp;num=&amp;lang=</code></td><td>App reviews</td></tr>
+            <tr><td>GET</td><td><code>/api/suggest?q=</code></td><td>Search autocomplete (promoted from <code>/apps/?suggest=</code>)</td></tr>
+<tr><td>GET</td><td><code>/api/apps/:appId/reviews?sort=&amp;num=&amp;lang=</code></td><td>App reviews</td></tr>
     </table>
 
     <h2>Browse</h2>

--- a/lib/index.js
+++ b/lib/index.js
@@ -130,13 +130,19 @@ router.get('/apps/',
       .catch(next);
   });
 
-/* Search suggest */
+/* Search suggest (legacy: ?suggest= on /apps/) */
 router.get('/apps/',
   query('suggest').optional().isString().trim().isLength({ min: 1 }).withMessage('suggest must be a non-empty string'),
   handleValidationErrors,
   function (req, res, next) {
     if (!req.query.suggest) {
       return next();
+    }
+
+    // Deprecated in favor of GET /suggest — signal on v1 per RFC 9745.
+    if (req.baseUrl === '/api') {
+      res.setHeader('Deprecation', 'true');
+      res.setHeader('Link', `<${buildUrl(req, '/suggest')}?${qs.stringify({ q: req.query.suggest, country: req.query.country, lang: req.query.lang })}>; rel="alternate"`);
     }
 
     const toJSON = (term) => ({
@@ -148,6 +154,25 @@ router.get('/apps/',
       .then((terms) => terms.map(toJSON))
       .then(toList)
       .then(d => validateSuggest(d, '/apps/suggest'))
+      .then(res.json.bind(res))
+      .catch(next);
+  });
+
+/* Search suggest (v2 promotion of the legacy ?suggest= param) */
+router.get('/suggest',
+  query('q').exists().withMessage('q is required (the partial search term to complete, e.g. q=spot)')
+    .isString().trim().isLength({ min: 1 }).withMessage('q must be a non-empty string'),
+  handleValidationErrors,
+  function (req, res, next) {
+    const toJSON = (term) => ({
+      term,
+      url: buildUrl(req, '/apps/') + '?' + qs.stringify({ q: term })
+    });
+
+    gplay.suggest({ term: req.query.q })
+      .then((terms) => terms.map(toJSON))
+      .then(toList)
+      .then(d => validateSuggest(d, '/suggest'))
       .then(res.json.bind(res))
       .catch(next);
   });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -497,6 +497,42 @@ test('batch rejects malformed JSON body', async () => {
   assert.equal(res.status, 400);
 });
 
+// ─── B5: GET /suggest promotion ─────────────────────────────────────────────
+
+test('suggest returns terms with search URLs', async () => {
+  const { status, body } = await get('/api/suggest?q=spot');
+  assert.equal(status, 200);
+  assert.equal(body.results.length, 2);
+  assert.equal(body.results[0].term, 'game');
+  assert.match(body.results[0].url, /\/apps\/\?q=game/);
+});
+
+test('suggest rejects a missing q with problem+json on /v2', async () => {
+  const { status, headers, body } = await get('/v2/suggest');
+  assert.equal(status, 400);
+  assert.match(headers.get('content-type'), /application\/problem\+json/);
+  assert.match(body.detail, /q is required/);
+});
+
+test('suggest rejects an empty q', async () => {
+  const { status, body } = await get('/api/suggest?q=');
+  assert.equal(status, 400);
+  assert.equal(body.error, 'Validation failed');
+  assert.match(body.messages[0], /q must be a non-empty string|q is required/);
+});
+
+test('legacy /apps/?suggest= works and sets Deprecation header on v1 only', async () => {
+  const v1 = await get('/api/apps/?suggest=spot');
+  assert.equal(v1.status, 200);
+  assert.equal(v1.body.results[0].term, 'game');
+  assert.equal(v1.headers.get('deprecation'), 'true');
+  assert.match(v1.headers.get('link') || '', /rel="alternate"/);
+
+  const v2 = await get('/v2/apps/?suggest=spot');
+  assert.equal(v2.status, 200);
+  assert.equal(v2.headers.get('deprecation'), null);
+});
+
 // ─── B2: country availability on /apps/:appId/availability ──────────────────
 
 test('availability forwards appId and parsed country codes to scraper', async () => {

--- a/v2-plan/DEFICIENCIES.md
+++ b/v2-plan/DEFICIENCIES.md
@@ -40,7 +40,7 @@
 | B2 | ✅ Fixed — `GET /apps/:appId/availability?countries=` | feature | Shipped: comma-separated ISO-2 codes, max 30, maps scraper statuses to `{available, status, message?}`. |
 | B3 | No streaming/bulk reviews export | feature | Scraper `reviewsAll` / `reviewsIterator`. Add `GET /api/apps/:appId/reviews/export` (NDJSON or CSV stream) as a premium-credit endpoint. |
 | B4 | No search/developer iterators exposed | feature | Scraper `searchIterator`, `developerIterator` for >200 results. Add cursor-paginated `GET /api/apps/search/all`. |
-| B5 | `suggest` buried as `?suggest=` query param on `/apps/` | refactor | Promote to `GET /api/suggest?q=`. Keep legacy param with deprecation header. |
+| B5 | ✅ Fixed — `GET /suggest?q=` | refactor | Shipped: dedicated endpoint; legacy `/apps/?suggest=` still works and returns `Deprecation: true` + `Link` (rel=alternate) headers on /api. |
 | B6 | List pagination emulated via fetch-and-slice | bug-perf | `start+num` fetched then sliced; wasteful. Use scraper iterators; document 200-cap honestly. |
 | B7 | `fullDetail` on search causes errors | bug | Upstream API issue #107. Validate/limit interaction in v2. |
 | B8 | ✅ Fixed — `?fields=` projection on app details | feature | Shipped as whitelist-validated projection (see lib/fields.js). Upstream API issue #22 ("take only a few fields"). |


### PR DESCRIPTION
Closes #118 (B5).

- New `GET /suggest?q=` endpoint (required non-empty `q`, inherits `country`/`lang` middleware defaults) returning the same `{results:[{term,url}]}` envelope, validated via `validateSuggest`.
- Legacy `/apps/?suggest=` still works and now sends `Deprecation: true` + `Link: <.../api/suggest?q=...>; rel="alternate"` on v1 (`/api`) per RFC 9745; v2 stays clean.
- Unit tests (103), Bruno unit collection (62/62) + full collection (70/70), lint clean.