### PR TITLE
B6: List pagination — shared offset pagination for /apps/ and /lists/

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -177,34 +177,42 @@ router.get('/suggest',
       .catch(next);
   });
 
-/* App list */
-router.get('/apps/', function (req, res, next) {
-  // @mradex77/google-play-scraper caps list() at 200 results and has no
-  // `start` offset; emulate offset pagination by fetching start + num and
-  // slicing, so the existing prev/next API contract is preserved.
+// Shared offset-pagination for list()-backed endpoints. The scraper has no
+// `start` offset and hard-caps results at MAX_LIST_RESULTS (200), so pages
+// are emulated by fetching start + num and slicing. `next` is only emitted
+// when another full page can exist within the cap — never a dangling link to
+// an empty page at/after 200.
+const listPage = (req) => {
   const num = Math.min(parseInt(req.query.num || String(MAX_LIST_RESULTS), 10) || MAX_LIST_RESULTS, MAX_LIST_RESULTS);
   const start = Math.max(parseInt(req.query.start || String(DEFAULT_START), 10) || 0, 0);
+  return { num, start };
+};
 
-  function paginate (apps) {
-    if (start - num >= 0) {
+function paginateList (req, path, num, start) {
+  return function paginate (apps) {
+    if (start - num >= 0 && start - num < MAX_LIST_RESULTS) {
       req.query.start = start - num;
-      apps.prev = buildUrl(req, '/apps/') + '?' + qs.stringify(req.query);
+      apps.prev = buildUrl(req, path) + '?' + qs.stringify(req.query);
     }
 
-    if (start + num <= MAX_LIST_RESULTS) {
+    if (start + num < MAX_LIST_RESULTS) {
       req.query.start = start + num;
-      apps.next = buildUrl(req, '/apps/') + '?' + qs.stringify(req.query);
+      apps.next = buildUrl(req, path) + '?' + qs.stringify(req.query);
     }
 
     return apps;
-  }
+  };
+}
 
+/* App list */
+router.get('/apps/', function (req, res, next) {
+  const { num, start } = listPage(req);
   const listOpts = Object.assign({}, req.query, { num: Math.min(start + num, MAX_LIST_RESULTS) });
 
   gplay.list(listOpts)
     .then((apps) => apps.slice(start, start + num))
     .then((apps) => apps.map(cleanUrls(req)))
-    .then(toList).then(paginate)
+    .then(toList).then(paginateList(req, '/apps/', num, start))
     .then(res.json.bind(res))
     .catch(next);
 });
@@ -528,14 +536,17 @@ router.get('/lists/',
   query('start').optional().isInt({ min: 0 }).withMessage('start must be a non-negative integer'),
   handleValidationErrors,
   function (req, res, next) {
+    const { num, start } = listPage(req);
     const opts = Object.assign({ term: req.query.q, country: req.query.country }, req.query);
 
-    opts.num = req.query.num ? parseInt(req.query.num, 10) : undefined;
+    opts.num = Math.min(start + num, MAX_LIST_RESULTS);
 
     gplay.list(opts)
+      .then((apps) => apps.slice(start, start + num))
       .then((apps) => apps.map(cleanUrls(req)))
       .then(toList)
       .then(d => validateAppList(d, '/lists/'))
+      .then(paginateList(req, '/lists/', num, start))
       .then(res.json.bind(res))
       .catch(next);
   });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -405,6 +405,38 @@ test('lists forwards category/collection to scraper list()', async () => {
   assert.equal(body.results.length, 1);
   fake.list = async (opts) => Array.from({ length: opts.num || 60 }, (_, i) => makeApp(`com.example.app${i}`));
 });
+test('lists paginates with start/num slicing and prev/next links', async () => {
+  let captured;
+  fake.list = async (opts) => { captured = opts; return Array.from({ length: opts.num }, (_, i) => makeApp(`com.example.app${i}`)); };
+  const { status, body } = await get('/api/lists/?category=GAME&collection=TOP_SELLING&num=10&start=20');
+  assert.equal(status, 200);
+  assert.equal(captured.num, 30); // fetches start + num, no native offset
+  assert.equal(body.results.length, 10);
+  assert.equal(body.results[0].appId, 'com.example.app20');
+  assert.match(body.prev, /start=10/);
+  assert.match(body.next, /start=30/);
+  fake.list = async (opts) => Array.from({ length: opts.num || 60 }, (_, i) => makeApp(`com.example.app${i}`));
+});
+
+test('lists omits next link at the end of the capped range', async () => {
+  fake.list = async (opts) => Array.from({ length: opts.num }, (_, i) => makeApp(`com.example.app${i}`));
+  const { status, body } = await get('/api/lists/?category=GAME&collection=TOP_SELLING&num=10&start=195');
+  assert.equal(status, 200);
+  assert.equal(body.results.length, 5); // only 200 - 195 apps remain
+  assert.ok(body.prev);
+  assert.equal(body.next, undefined);
+  fake.list = async (opts) => Array.from({ length: opts.num || 60 }, (_, i) => makeApp(`com.example.app${i}`));
+});
+
+test('app list omits next link when a full last page reaches exactly 200', async () => {
+  fake.list = async (opts) => Array.from({ length: opts.num }, (_, i) => makeApp(`com.example.app${i}`));
+  const { status, body } = await get('/api/apps/?num=10&start=190');
+  assert.equal(status, 200);
+  assert.equal(body.results.length, 10);
+  assert.match(body.prev, /start=180/);
+  assert.equal(body.next, undefined); // start=200 would be an empty page
+  fake.list = async (opts) => Array.from({ length: opts.num || 60 }, (_, i) => makeApp(`com.example.app${i}`));
+});
 
 // ─── /categories/ and /collections/ ──────────────────────────────────────────
 


### PR DESCRIPTION
Closes #120.

The scraper has no `start` offset and hard-caps `list()` at 200 results, so offset pagination is emulated by fetching `start + num` and slicing. This PR:

- Extracts `listPage()`/`paginateList()` shared by `/apps/` and `/lists/`
- Gives `/lists/` the same `start`/`num` slicing + `prev`/`next` links as `/apps/`
- Omits `next` when a full last page reaches exactly the 200 cap (no dangling link to an empty page at/after `start=200`)
- Omits `prev` when it would point past the cap

Tests: slicing, prev/next links, cap-boundary behaviour. All 70 unit tests + v2 contract checks pass.